### PR TITLE
Fix: ECDSAStakeRegistry and DeplomentLibs now set owner 

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -6,7 +6,8 @@ fs_permissions = [{ access = "read-write", path = "./" }]
 solc = "0.8.27"
 via-ir = true
 optimizer = true
-optimizer_runs = 1000000 # Higher number optimizes for frequent contract calls, lower number optimizes for deployment cost
+optimizer_runs = 1000000
+ # Higher number optimizes for frequent contract calls, lower number optimizes for deployment cost
 
 
 remappings = [

--- a/contracts/script/utils/HelloWorldDeploymentLib.sol
+++ b/contracts/script/utils/HelloWorldDeploymentLib.sol
@@ -54,7 +54,7 @@ library HelloWorldDeploymentLib {
         );
         // Upgrade contracts
         bytes memory upgradeCall = abi.encodeCall(
-            ECDSAStakeRegistry.initialize, (result.helloWorldServiceManager, 0, quorum)
+            ECDSAStakeRegistry.initialize, (result.helloWorldServiceManager, 0, quorum, msg.sender)
         );
         UpgradeableProxyLib.upgradeAndCall(result.stakeRegistry, stakeRegistryImpl, upgradeCall);
         UpgradeableProxyLib.upgrade(result.helloWorldServiceManager, helloWorldServiceManagerImpl);

--- a/contracts/script/utils/LayerMiddlewareDeplomentLib.sol
+++ b/contracts/script/utils/LayerMiddlewareDeplomentLib.sol
@@ -54,7 +54,7 @@ library LayerMiddlewareDeploymentLib {
         );
         // Upgrade contracts
         bytes memory upgradeCall = abi.encodeCall(
-            ECDSAStakeRegistry.initialize, (result.layerServiceManager, 0, quorum)
+            ECDSAStakeRegistry.initialize, (result.layerServiceManager, 0, quorum, msg.sender)
         );
         UpgradeableProxyLib.upgradeAndCall(result.stakeRegistry, stakeRegistryImpl, upgradeCall);
         UpgradeableProxyLib.upgrade(result.layerServiceManager, layerServiceManagerImpl);


### PR DESCRIPTION
Fixed error where admin was owner causing fallback logic when trying to updateQuorumConfig 