### PR TITLE
Update register to accept private key as argument

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -51,5 +51,8 @@ docker run --rm --network host --env-file .env  -v ./.nodes:/root/.nodes   --ent
 Register: 
 
 ```bash
-docker run --rm --network host --env-file .env -v ./.nodes:/root/.nodes  --entrypoint /wavs/register.sh wavs-middleware
+# TODO: get the private AVS key (0x...) for this service from the WAVS node
+AVS_KEY=0x974b676703542ff93841c3daeeabcbfdb6ba62101856e22d5fb6b9d2f9db42fd
+
+docker run --rm --network host --env-file .env -v ./.nodes:/root/.nodes  --entrypoint /wavs/register.sh wavs-middleware "$AVS_KEY"
 ```

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -154,10 +154,6 @@ update_metadata_url() {
 update_quorum_config() {
     local owner="$1"
     local stakeRegistryAddress="$2"
-    if [ "$QUICK_MODE" = "ON" ]; then
-        echo "QUICK_MODE is ON - skipping update quorum config"
-        return 0
-    fi
     impersonate_account "$owner"
     
     if [ "$DEPLOY_ENV" = "TESTNET" ]; then

--- a/docker/register.sh
+++ b/docker/register.sh
@@ -32,8 +32,10 @@ if [ -z "$WAVSServiceManagerAddress" ]; then
 fi
 
 setup_operator() {
-    local index=$1
-    local WAVSServiceManagerAddress=$2
+    local WAVSServiceManagerAddress=$1
+    local private_key=$2
+    local public_key=$(cast wallet address $private_key)
+
     STRATEGY_MANAGER_ADDRESS=$(jq -r '.addresses.strategyManager' contracts/deployments/core/$CHAIN_ID.json)
     if [ -z "$STRATEGY_MANAGER_ADDRESS" ]; then
         echo "Error: Failed to read strategyManagerAddress from contracts/deployments/core/$CHAIN_ID.json"
@@ -44,16 +46,18 @@ setup_operator() {
         echo "Error: Failed to read delegationManagerAddress from contracts/deployments/core/$CHAIN_ID.json"
         exit 1
     fi
-    local mnemonic=$(cast wallet nm --json | jq -r '.mnemonic')
-    local private_key=$(cast wallet pk "$mnemonic")
-    local public_key=$(cast wallet address $private_key)
+
     
     if [ "$DEPLOY_ENV" = "TESTNET" ]; then
+        # TODO: remove this and replace with a check the AVS key has a balance
         cast s "$public_key" --value 50000000000000000 --private-key "$FUNDED_KEY" -r "$LOCAL_ETHEREUM_RPC_URL" > /dev/null 2>&1
         if [ $? -ne 0 ]; then
             echo "Error: Failed to give operator $index balance"
             exit 1
         fi
+
+        # TODO: use this in both testnet and local - which LST do we use?
+        # See https://github.com/Lay3rLabs/wavs-middleware/issues/61
         MINT_FUNCTION="submit(address _referral)"
         cast send "$LST_CONTRACT_ADDRESS" "$MINT_FUNCTION" "$public_key" "0x0000000000000000000000000000000000000000" \
             --private-key "$private_key" \
@@ -83,7 +87,7 @@ setup_operator() {
         cast rpc anvil_setBalance $public_key 0x10000000000000000000 -r $LOCAL_ETHEREUM_RPC_URL > /dev/null 2>&1
     fi
     if [ $? -ne 0 ]; then
-        echo "Failed to set balance for operator $index"
+        echo "Failed to set balance for operator"
         exit 1
     fi
 
@@ -97,6 +101,7 @@ setup_operator() {
         exit 1
     fi
 
+    # TODO: what is this magic 0x1234 number here? Maybe we want a real variable for it?
     allocationManager=$(cast call "$WAVSServiceManagerAddress" "allocationManager()" --rpc-url "$LOCAL_ETHEREUM_RPC_URL" | cast parse-bytes32-address)
     cast s "$allocationManager" \
         "registerForOperatorSets(address,(address,uint32[],bytes))" \
@@ -113,13 +118,21 @@ setup_operator() {
 
     export PRIVATE_KEY=$private_key
     export TESTNET_RPC_URL="$LOCAL_ETHEREUM_RPC_URL"  
+
+    # TODO: pull some stuff out of Rust into bash
+    # See https://github.com/Lay3rLabs/wavs-middleware/issues/52
+    # and https://github.com/Lay3rLabs/wavs-middleware/issues/42
     /wavs/register_layer_operator #> /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "Error: Failed to register operator $public_key to operator sets"
         exit 1
     fi
-    echo "PRIVATE_KEY_${index}=$private_key" > ~/.nodes/operator$index
-    echo "MNEMONIC_${index}=$mnemonic" > ~/.nodes/operator_mnemonic$index
+
+    # TODO: add a query of the current voting power of this operator on the stake registry
 }
 
-setup_operator 1 "$WAVSServiceManagerAddress"
+if [ -z "$1" ]; then
+    echo "Error: Pass private AVS Key as first arg"
+    exit 1
+fi
+setup_operator "$WAVSServiceManagerAddress" "$1"


### PR DESCRIPTION
Closes #60 

Merge this after #64 is approved and merged

This takes a private AVS Key from the WAVS node to be used for registration.

Also added a lot of comments on register.sh that should be fixed up in follow-up issues.
In particular, https://github.com/Lay3rLabs/wavs-middleware/issues/61 and using a real LST on the dry run as well so we can test the same config we are really going to deploy with.