### PR TITLE
feat: npm compatible 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "wavs-middleware",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wavs-middleware",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wavs-middleware",
-  "version": "1.0.0",
+  "version": "0.4.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wavs-middleware",
-      "version": "1.0.0",
+      "version": "0.4.0-alpha.1",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "wavs-middleware",
+  "version": "1.0.0",
+  "description": "WAVS Middleware",
+  "main": "index.js",
+  "author": "Lay3rLabs Team",
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "wavs-middleware",
   "version": "1.0.0",
   "description": "WAVS Middleware",
-  "main": "index.js",
   "author": "Lay3rLabs Team",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavs-middleware",
-  "version": "1.0.0",
+  "version": "0.4.0-alpha.1",
   "description": "WAVS Middleware",
   "author": "Lay3rLabs Team",
   "license": "MIT"


### PR DESCRIPTION
ref: https://github.com/Lay3rLabs/wavs-middleware/issues/32

https://github.com/Lay3rLabs/wavs-foundry-template/pull/119

While upgrading the template to this repo it required this small change, the repo must have a package.json. nothing else is required

https://github.com/Lay3rLabs/wavs-foundry-template/blob/92b50949ae56ea779388758a48f8cb5c42ec8902/package.json#L28
