### PR TITLE
fix: docker build latest git submodules if none exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM ubuntu:latest AS git-deps
 RUN apt update && apt install -yq git
-COPY . /tmp/
-RUN cd /tmp && git submodule update --init --recursive
+RUN mkdir -p /tmp/contracts/lib
+COPY .gitmodules contracts/lib /tmp/
+WORKDIR /tmp
+# a git env required to submodule pull
+RUN git init
+RUN git submodule update --init --recursive
 
 FROM rust AS builder
 COPY operator /wavs/operator/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM rust AS builder
+FROM ubuntu:latest AS git-deps
+RUN apt update && apt install -yq git
+COPY . /tmp/
+RUN cd /tmp && git submodule update --init --recursive
 
+FROM rust AS builder
 COPY operator /wavs/operator/
 WORKDIR /wavs/operator
 RUN cargo build --release
@@ -13,8 +17,12 @@ COPY --from=builder /wavs/operator/target/release/register_layer_operator /wavs/
 RUN chmod +x /wavs/register_layer_operator
 
 COPY contracts /wavs/contracts
+COPY --from=git-deps /tmp/contracts/lib /wavs/contracts/lib
+
 WORKDIR /wavs/contracts
 RUN forge build
+
+RUN rm -rf /tmp
 
 WORKDIR /wavs
 COPY ./docker/*.sh /wavs


### PR DESCRIPTION
## Summary

- Before the docker image would __only__ build if you had run `git submodule update --init --recursive` before `docker build`. To ensure new clones (and gh actions in the future), a git modules update and copy over is performed. 
- While `git-deps` uses ubuntu:latest, only the files are copied over. This results in the exact same image size as before, no extra overhead.
- git-deps is first so it can be cached & does not require submodule downloads on all subsequent builds