### PR TITLE
Expose key stake registry queries on the service manager

### DIFF
--- a/contracts/interfaces/IWavsServiceManager.sol
+++ b/contracts/interfaces/IWavsServiceManager.sol
@@ -10,6 +10,28 @@ interface IWavsServiceManager {
     // ------------------------------------------------------------------------
     error InvalidSignature();
     event ServiceURIUpdated(string serviceURI);
+
+    // ------------------------------------------------------------------------
+    // Stake Registry View Functions
+    // ------------------------------------------------------------------------
+    /**
+     * @notice Gets the operator's current weight
+     * @param operator The address of the operator
+     * @return The current weight of the operator
+     */
+    function getOperatorWeight(address operator) external view returns (uint256);
+
+    /**
+     * @notice Gets the total weight from the last checkpoint
+     * @return The total weight from the last checkpoint
+     */
+    function getLastCheckpointTotalWeight() external view returns (uint256);
+
+    /**
+     * @notice Gets the threshold weight from the last checkpoint
+     * @return The threshold weight from the last checkpoint
+     */
+    function getLastCheckpointThresholdWeight() external view returns (uint256);
     /**
      * @param envelope The envelope containing the data.
      * @param signatureData The signature data.

--- a/contracts/src/WavsServiceManager.sol
+++ b/contracts/src/WavsServiceManager.sol
@@ -167,6 +167,7 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
         bytes32 message = keccak256(abi.encode(envelope));
         bytes32 ethSignedMessageHash = ECDSAUpgradeable.toEthSignedMessageHash(message);
         bytes4 magicValue = IERC1271Upgradeable.isValidSignature.selector;
+
         bytes memory signatureDataBytes = abi.encode(signatureData.operators, signatureData.signatures, signatureData.referenceBlock);
         // If the registry returns the magicValue, signature is considered valid
         if( magicValue !=
@@ -177,6 +178,21 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
         ) {
             revert IWavsServiceManager.InvalidSignature();
         }
+    }
+
+    /// @inheritdoc IWavsServiceManager
+    function getOperatorWeight(address operator) external view returns (uint256) {
+        return ECDSAStakeRegistry(stakeRegistry).getLastCheckpointOperatorWeight(operator);
+    }
+
+    /// @inheritdoc IWavsServiceManager
+    function getLastCheckpointTotalWeight() external view returns (uint256) {
+        return ECDSAStakeRegistry(stakeRegistry).getLastCheckpointTotalWeight();
+    }
+
+    /// @inheritdoc IWavsServiceManager
+    function getLastCheckpointThresholdWeight() external view returns (uint256) {
+        return ECDSAStakeRegistry(stakeRegistry).getLastCheckpointThresholdWeight();
     }
 
 }


### PR DESCRIPTION
Closes #58 
Closes #59 

@dakom You can use this new interface in the WAVS code as well (I guess just copy it over). Maybe you have this in mocks now, let's just sync on the IWavsServiceManager stuff