### PR TITLE
fix: depositIntoStrategy for local operator weights

### DIFF
--- a/docker/register.sh
+++ b/docker/register.sh
@@ -47,7 +47,6 @@ setup_operator() {
         exit 1
     fi
 
-    
     if [ "$DEPLOY_ENV" = "TESTNET" ]; then
         # TODO: remove this and replace with a check the AVS key has a balance
         cast s "$public_key" --value 50000000000000000 --private-key "$FUNDED_KEY" -r "$LOCAL_ETHEREUM_RPC_URL" > /dev/null 2>&1
@@ -55,39 +54,36 @@ setup_operator() {
             echo "Error: Failed to give operator $index balance"
             exit 1
         fi
-
-        # TODO: use this in both testnet and local - which LST do we use?
-        # See https://github.com/Lay3rLabs/wavs-middleware/issues/61
-        MINT_FUNCTION="submit(address _referral)"
-        cast send "$LST_CONTRACT_ADDRESS" "$MINT_FUNCTION" "$public_key" "0x0000000000000000000000000000000000000000" \
-            --private-key "$private_key" \
-            --value 10000000000000000 \
-            --rpc-url "$LOCAL_ETHEREUM_RPC_URL" > /dev/null 2>&1
-        if [ $? -ne 0 ]; then
-            echo "Error: Failed to mint LST for $ADDRESS"
-            exit 1
-        fi
-        cast send "$LST_CONTRACT_ADDRESS" "approve(address,uint256)" \
-            "$STRATEGY_MANAGER_ADDRESS" 10000000000000000 \
-            --private-key "$private_key" \
-            --rpc-url "$LOCAL_ETHEREUM_RPC_URL" > /dev/null 2>&1
-        if [ $? -ne 0 ]; then
-            echo "Error: Failed to approve LST for $STRATEGY_MANAGER_ADDRESS"
-            exit 1
-        fi
-        cast send "$STRATEGY_MANAGER_ADDRESS" "depositIntoStrategy(address,address,uint256)" \
-            "$LST_STRATEGY_ADDRESS" "$LST_CONTRACT_ADDRESS" 10000000000000000 \
-            --private-key "$private_key" \
-            --rpc-url "$LOCAL_ETHEREUM_RPC_URL" > /dev/null 2>&1
-        if [ $? -ne 0 ]; then
-            echo "Error: Failed to deposit into strategy for $LST_STRATEGY_ADDRESS"
-            exit 1
-        fi
     else
         cast rpc anvil_setBalance $public_key 0x10000000000000000000 -r $LOCAL_ETHEREUM_RPC_URL > /dev/null 2>&1
     fi
     if [ $? -ne 0 ]; then
         echo "Failed to set balance for operator"
+        exit 1
+    fi
+
+    cast send "$LST_CONTRACT_ADDRESS" "submit(address _referral)" "$public_key" "0x0000000000000000000000000000000000000000" \
+        --private-key "$private_key" \
+        --value 10000000000000000 \
+        --rpc-url "$LOCAL_ETHEREUM_RPC_URL" > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to mint LST for $ADDRESS"
+        exit 1
+    fi
+    cast send "$LST_CONTRACT_ADDRESS" "approve(address,uint256)" \
+        "$STRATEGY_MANAGER_ADDRESS" 10000000000000000 \
+        --private-key "$private_key" \
+        --rpc-url "$LOCAL_ETHEREUM_RPC_URL" > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to approve LST for $STRATEGY_MANAGER_ADDRESS"
+        exit 1
+    fi
+    cast send "$STRATEGY_MANAGER_ADDRESS" "depositIntoStrategy(address,address,uint256)" \
+        "$LST_STRATEGY_ADDRESS" "$LST_CONTRACT_ADDRESS" 10000000000000000 \
+        --private-key "$private_key" \
+        --rpc-url "$LOCAL_ETHEREUM_RPC_URL" > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to deposit into strategy for $LST_STRATEGY_ADDRESS"
         exit 1
     fi
 
@@ -117,7 +113,7 @@ setup_operator() {
     fi
 
     export PRIVATE_KEY=$private_key
-    export TESTNET_RPC_URL="$LOCAL_ETHEREUM_RPC_URL"  
+    export TESTNET_RPC_URL="$LOCAL_ETHEREUM_RPC_URL"
 
     # TODO: pull some stuff out of Rust into bash
     # See https://github.com/Lay3rLabs/wavs-middleware/issues/52


### PR DESCRIPTION
closes #78 and ref: #73

before the LST_CONTRACT_ADDRESS was `TESTNET` only. This resulted in `weight: 0`. The wavs-aggregator requires weight to be >1

This change allows LOCAL testnets to work as expected with the aggregator

Operator weight >0
![image](https://github.com/user-attachments/assets/5a86deab-5e58-4767-8e83-676272856df8)

wavs aggregator working (final output)
![image](https://github.com/user-attachments/assets/dba5d1bc-3988-4c26-88ed-850558ad0510)
