### PR TITLE
Build and publish docker images in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,6 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: lay3rlabs/wavs-middleware
 
-
 jobs:
   build_amd64:
     name: Build and Push AMD64 Image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v4
 
+      - name: Pull submodules recursively
+        run: git submodule update --init --recursive
+
       - name: Set IMAGE_TAG
         shell: bash
         run: |
@@ -68,6 +71,9 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
+
+      - name: Pull submodules recursively
+        run: git submodule update --init --recursive
 
       - name: Set IMAGE_TAG
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: lay3rlabs/wavs-middleware
 
+
 jobs:
   build_amd64:
     name: Build and Push AMD64 Image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,141 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - dev
+  # You can enable the below to build on each PR push for testing,
+  pull_request:
+    branches:
+      - dev
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: lay3rlabs/wavs-middleware
+
+jobs:
+  build_amd64:
+    name: Build and Push AMD64 Image
+    runs-on: linux-8-core
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Set IMAGE_TAG
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            TAG="${GITHUB_REF_NAME#v}"
+            IMAGE_TAG="${TAG//[^a-zA-Z0-9_.-]/-}"
+          elif [[ "${GITHUB_REF_NAME}" == "dev" ]]; then
+            IMAGE_TAG="latest"
+          else
+            IMAGE_TAG="${GITHUB_REF_NAME//\//-}"
+          fi
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push AMD64 image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-amd64
+          platforms: linux/amd64
+          provenance: false
+
+  build_arm64:
+    name: Build and Push ARM64 Image
+    runs-on: arm64-builder
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Set IMAGE_TAG
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            TAG="${GITHUB_REF_NAME#v}"
+            IMAGE_TAG="${TAG//[^a-zA-Z0-9_.-]/-}"
+          elif [[ "${GITHUB_REF_NAME}" == "dev" ]]; then
+            IMAGE_TAG="latest"
+          else
+            IMAGE_TAG="${GITHUB_REF_NAME//\//-}"
+          fi
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ARM64 image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-arm64
+          platforms: linux/arm64
+          provenance: false
+
+  create_manifest:
+    name: Create and Push Multi-Arch Manifest
+    runs-on: ubuntu-latest
+    needs: [build_amd64, build_arm64]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Set IMAGE_TAG
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            TAG="${GITHUB_REF_NAME#v}"
+            IMAGE_TAG="${TAG//[^a-zA-Z0-9_.-]/-}"
+          elif [[ "${GITHUB_REF_NAME}" == "dev" ]]; then
+            IMAGE_TAG="latest"
+          else
+            IMAGE_TAG="${GITHUB_REF_NAME//\//-}"
+          fi
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-arm64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,9 @@ on:
     branches:
       - dev
   # You can enable the below to build on each PR push for testing,
-  pull_request:
-    branches:
-      - dev
+  # pull_request:
+  #   branches:
+  #     - dev
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,9 @@
-FROM ubuntu:latest AS git-deps
-RUN apt update && apt install -yq git
-RUN mkdir -p /tmp/contracts/lib
-COPY .gitmodules contracts/lib /tmp/
-WORKDIR /tmp
-# a git env required to submodule pull
-RUN git init
-RUN git submodule update --init --recursive
-
 FROM ghcr.io/foundry-rs/foundry:latest
-
 USER root
 RUN apt update && apt install -yq jq curl
 
 COPY contracts /wavs/contracts
-COPY --from=git-deps /tmp/contracts/lib /wavs/contracts/lib
-
-WORKDIR /wavs/contracts
-RUN forge build
+RUN forge build --root /wavs/contracts
 
 RUN rm -rf /tmp
 


### PR DESCRIPTION
Closes #86 

This should build and publish a multi-arch build on any tag.
It will also build a `latest` tag on any merge to main.