### PR TITLE
Use our fork, and explicitly tag middleware

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,10 @@
 [submodule "contracts/lib/forge-std"]
 	path = contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+	fetchRecurseSubmodules = true
 [submodule "contracts/lib/eigenlayer-middleware"]
 	path = contracts/lib/eigenlayer-middleware
 	url = https://github.com/Lay3rLabs/eigenlayer-middleware
-	# This is tag v1.1.1-testnet-slashing
+	# This commit hash (848032a7e22b2e6a2ab7835a45e9b39bb16d41a5) corresponds to tag v1.1.1-testnet-slashing
 	branch = 848032a7e22b2e6a2ab7835a45e9b39bb16d41a5 
+	fetchRecurseSubmodules = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,6 @@
 	url = https://github.com/foundry-rs/forge-std
 [submodule "contracts/lib/eigenlayer-middleware"]
 	path = contracts/lib/eigenlayer-middleware
-	url = https://github.com/BreadchainCoop/eigenlayer-middleware
-	branch = dev 
+	url = https://github.com/Lay3rLabs/eigenlayer-middleware
+	# This is tag v1.1.1-testnet-slashing
+	branch = 848032a7e22b2e6a2ab7835a45e9b39bb16d41a5 


### PR DESCRIPTION
Closes #80 

- Use Lay3rLabs fork of eigenlayer-middleware, rather than BreadchainCoop.
- Explicitly mention what version we use (`v1.1.1-testnet-slashing`) rather than just `dev`. (The commit hash we are using as submodule didn't change, just exposed in the `.gitmodules` for easier tracking