### PR TITLE
Trim down Service Manager interface

### DIFF
--- a/contracts/eigenlayer/src/WavsServiceManager.sol
+++ b/contracts/eigenlayer/src/WavsServiceManager.sol
@@ -184,15 +184,4 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
     function getOperatorWeight(address operator) external view returns (uint256) {
         return ECDSAStakeRegistry(stakeRegistry).getLastCheckpointOperatorWeight(operator);
     }
-
-    /// @inheritdoc IWavsServiceManager
-    function getLastCheckpointTotalWeight() external view returns (uint256) {
-        return ECDSAStakeRegistry(stakeRegistry).getLastCheckpointTotalWeight();
-    }
-
-    /// @inheritdoc IWavsServiceManager
-    function getLastCheckpointThresholdWeight() external view returns (uint256) {
-        return ECDSAStakeRegistry(stakeRegistry).getLastCheckpointThresholdWeight();
-    }
-
 }

--- a/contracts/interfaces/IWavsServiceManager.sol
+++ b/contracts/interfaces/IWavsServiceManager.sol
@@ -22,17 +22,6 @@ interface IWavsServiceManager {
     function getOperatorWeight(address operator) external view returns (uint256);
 
     /**
-     * @notice Gets the total weight from the last checkpoint
-     * @return The total weight from the last checkpoint
-     */
-    function getLastCheckpointTotalWeight() external view returns (uint256);
-
-    /**
-     * @notice Gets the threshold weight from the last checkpoint
-     * @return The threshold weight from the last checkpoint
-     */
-    function getLastCheckpointThresholdWeight() external view returns (uint256);
-    /**
      * @param envelope The envelope containing the data.
      * @param signatureData The signature data.
      */

--- a/contracts/mocks/SimpleServiceManager.sol
+++ b/contracts/mocks/SimpleServiceManager.sol
@@ -31,17 +31,4 @@ contract SimpleServiceManager is IWavsServiceManager {
     ) external pure override returns (uint256) {
         return 1; // hard-coded at 1 for demo purposes
     }
-
-    function getLastCheckpointThresholdWeight()
-        external
-        pure
-        override
-        returns (uint256)
-    {
-        return 3; // hard-coded at 3 for demo purposes
-    }
-
-    function getLastCheckpointTotalWeight() external pure override returns (uint256) {
-        return 5; // hard-coded at 5 for demo purposes
-    }
 }


### PR DESCRIPTION
Closes #100 

Removes some methods that are not needed (should not be used) after https://github.com/Lay3rLabs/WAVS/issues/621