### PR TITLE
Update eigenlayer 1.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 [submodule "contracts/lib/eigenlayer-middleware"]
 	path = contracts/lib/eigenlayer-middleware
 	url = https://github.com/Lay3rLabs/eigenlayer-middleware
-	# This commit hash (848032a7e22b2e6a2ab7835a45e9b39bb16d41a5) corresponds to tag v1.1.1-testnet-slashing
-	branch = 848032a7e22b2e6a2ab7835a45e9b39bb16d41a5 
+	# This commit hash (4d63f27247587607beb67f96fdabec4b2c1321ef) corresponds to tag v1.4.0-testnet-holesky
+	branch = 4d63f27247587607beb67f96fdabec4b2c1321ef 

--- a/contracts/eigenlayer/src/WavsServiceManager.sol
+++ b/contracts/eigenlayer/src/WavsServiceManager.sol
@@ -13,7 +13,7 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 import {IRewardsCoordinator} from "@eigenlayer/contracts/interfaces/IRewardsCoordinator.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {IAllocationManager, IAllocationManagerTypes} from "@eigenlayer/contracts/interfaces/IAllocationManager.sol";
-import {ISignatureUtils} from "@eigenlayer/contracts/interfaces/ISignatureUtils.sol";
+import {ISignatureUtilsMixinTypes} from "@eigenlayer/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {IAVSRegistrar} from "@eigenlayer/contracts/interfaces/IAVSRegistrar.sol";
 import {IStrategy} from "@eigenlayer/contracts/interfaces/IStrategy.sol";
 import {IWavsServiceHandler} from "../../interfaces/IWavsServiceHandler.sol";
@@ -82,7 +82,7 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
     function registerOperatorToOperatorSets(
         address operator,
         uint32[] calldata operatorSetIds,
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+        ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature
     ) external {
         // Implementation logic here
     }


### PR DESCRIPTION
Fixed issue #43 
Updated eigenlayer submodule to version v1.4.0

Note - you must do `git submodule update --init --recursive`, but you maybe need to delete repository and checkout again for recursive submodules to update properly.
