### PR TITLE
feat: `PAST_BLOCKS` optional env

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ List Operators:
 # View stake registry status, including registered operators and their weights
 docker run --rm --network host  --env-file .env \
    -e WAVS_SERVICE_MANAGER_ADDRESS=${WAVS_SERVICE_MANAGER_ADDRESS} \
+   -e PAST_BLOCKS=1000 \
    wavs-middleware list_operator
 ```
 
@@ -116,7 +117,7 @@ Same as the local deploy, but add `TESTNET_RPC_URL` to the .env and change `DEPL
 ## References
 
 - [EigenLayer Documentation](https://docs.eigenlayer.xyz/)
-- [Hello World AVS Repository](https://github.com/Layr-Labs/eigenlayer-hello-world)
+- [Hello World AVS Repository](https://github.com/Layr-Labs/hello-world-avs)
 
 ## Deployment Process Flow
 

--- a/docker/list_operator.sh
+++ b/docker/list_operator.sh
@@ -11,6 +11,8 @@ SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR"/helpers.sh
 
+PAST_BLOCKS=${PAST_BLOCKS:-1000}
+
 if [ "$DEPLOY_ENV" = "TESTNET" ]; then
     LOCAL_ETHEREUM_RPC_URL="$TESTNET_RPC_URL"
 else
@@ -36,10 +38,11 @@ echo "Threshold Weight: $THRESHOLD_WEIGHT"
 
 # Get current block height and calculate range
 LATEST_BLOCK=$(cast block-number --rpc-url "$LOCAL_ETHEREUM_RPC_URL")
-FROM_BLOCK=$((LATEST_BLOCK - 900))
+FROM_BLOCK=$((LATEST_BLOCK - PAST_BLOCKS))
 
 # Get all OperatorRegistered events
 echo -e "\n=== Registered Operators ==="
+echo "Using a look-back period of $PAST_BLOCKS blocks"
 echo "Querying events from block $FROM_BLOCK to $LATEST_BLOCK"
 OPERATOR_EVENTS=$(cast logs --address "$STAKE_REGISTRY_ADDRESS" --from-block "$FROM_BLOCK" --to-block latest "OperatorRegistered(address, address)" --rpc-url "$LOCAL_ETHEREUM_RPC_URL")
 


### PR DESCRIPTION
closes #123 

## Summary

Adds a new (optional) env for the block scanning of OperatorRegister events. Setting PAST_BLOCKS will limit to this amount of lookback. 

### Reason

Some providers allow 2000+ blocks of lookback, others only 1000, and Alchemy only 500. I have not yet tested mainnet but I think they limit it to 64 -128 blocks or something insanely low there. So there is no reasonable set value we can do, just have to make it configurable.

The template will default to 500 for the time being once integrated