### PR TITLE
Add getLatestOperatorForSigningKey on service manager

### DIFF
--- a/contracts/eigenlayer/src/WavsServiceManager.sol
+++ b/contracts/eigenlayer/src/WavsServiceManager.sol
@@ -274,4 +274,9 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
     function getOperatorWeight(address operator) external view returns (uint256) {
         return ECDSAStakeRegistry(stakeRegistry).getLastCheckpointOperatorWeight(operator);
     }
+
+    /// @inheritdoc IWavsServiceManager
+    function getLatestOperatorForSigningKey(address signingKey) external view returns(address) {
+        return ECDSAStakeRegistry(stakeRegistry).getLatestOperatorForSigningKey(signingKey);
+    }
 }

--- a/contracts/interfaces/IWavsServiceManager.sol
+++ b/contracts/interfaces/IWavsServiceManager.sol
@@ -43,4 +43,11 @@ interface IWavsServiceManager {
      * @param _serviceURI The service URI to update.
      */
     function setServiceURI(string calldata _serviceURI) external;
+
+     /**
+     * @notice Retrieves the latest operator address associated with a signing key.
+     * @param signingKey The address of the signing key.
+     * @return The latest operator address associated with the signing key, or address(0) if none.
+     */
+    function getLatestOperatorForSigningKey(address signingKey) external view returns(address);
 }

--- a/contracts/mocks/SimpleServiceManager.sol
+++ b/contracts/mocks/SimpleServiceManager.sol
@@ -95,4 +95,10 @@ contract SimpleServiceManager is IWavsServiceManager {
     function getLastCheckpointTotalWeight() external view returns (uint256) {
         return lastCheckpointTotalWeight;
     }
+
+    function getLatestOperatorForSigningKey(
+        address signingKey
+    ) external pure override returns (address) {
+        return signingKey;
+    }
 }


### PR DESCRIPTION
https://github.com/Lay3rLabs/wavs-foundry-template/pull/178#issuecomment-2919396199

Currently getting this error in the template: `error InsufficientQuorum();`

Attempting the suggestion from comment