### PR TITLE
126 fix service manager

### DIFF
--- a/contracts/eigenlayer/src/WavsServiceManager.sol
+++ b/contracts/eigenlayer/src/WavsServiceManager.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.9;
 import {ECDSAServiceManagerBase} from
     "@eigenlayer-middleware/src/unaudited/ECDSAServiceManagerBase.sol";
 import {ECDSAStakeRegistry} from "@eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol";
+import {IECDSAStakeRegistry} from "@eigenlayer-middleware/src/unaudited/ECDSAStakeRegistryStorage.sol";
+
 import {IServiceManager} from "@eigenlayer-middleware/src/interfaces/IServiceManager.sol";
 import {ECDSAUpgradeable} from
     "@openzeppelin-upgrades/contracts/utils/cryptography/ECDSAUpgradeable.sol";
@@ -209,11 +211,15 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
         }
 
         // Calculate the total weight of the operators that signed
-        ECDSAStakeRegistry registry = ECDSAStakeRegistry(stakeRegistry);
+        IECDSAStakeRegistry registry = IECDSAStakeRegistry(stakeRegistry);
         uint256 signedWeight = 0;
         for (uint256 i = 0; i < signatureData.signers.length; i++) {
-            signedWeight += registry.getOperatorWeightAtBlock(
+            address operator = registry.getOperatorForSigningKeyAtBlock(
                 signatureData.signers[i], 
+                signatureData.referenceBlock
+            );
+            signedWeight += registry.getOperatorWeightAtBlock(
+                operator, 
                 signatureData.referenceBlock
             );
         }

--- a/contracts/eigenlayer/src/WavsServiceManager.sol
+++ b/contracts/eigenlayer/src/WavsServiceManager.sol
@@ -181,7 +181,7 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
         IWavsServiceHandler.SignatureData calldata signatureData
     ) external view {
         // Input validation
-        if (signatureData.operators.length == 0 || signatureData.operators.length != signatureData.signatures.length) {
+        if (signatureData.signers.length == 0 || signatureData.signers.length != signatureData.signatures.length) {
             revert IWavsServiceManager.InvalidSignature();
         }
         if (signatureData.referenceBlock >= block.number) {
@@ -195,7 +195,7 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
         // Validate signatures through the stake registry
         bytes4 magicValue = IERC1271Upgradeable.isValidSignature.selector;
         bytes memory signatureDataBytes = abi.encode(
-            signatureData.operators, 
+            signatureData.signers, 
             signatureData.signatures, 
             signatureData.referenceBlock
         );
@@ -211,9 +211,9 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
         // Calculate the total weight of the operators that signed
         ECDSAStakeRegistry registry = ECDSAStakeRegistry(stakeRegistry);
         uint256 signedWeight = 0;
-        for (uint256 i = 0; i < signatureData.operators.length; i++) {
+        for (uint256 i = 0; i < signatureData.signers.length; i++) {
             signedWeight += registry.getOperatorWeightAtBlock(
-                signatureData.operators[i], 
+                signatureData.signers[i], 
                 signatureData.referenceBlock
             );
         }

--- a/contracts/eigenlayer/test/WavsServiceManager.t.sol
+++ b/contracts/eigenlayer/test/WavsServiceManager.t.sol
@@ -55,6 +55,22 @@ contract MockStakeRegistry {
     function getLastCheckpointOperatorWeight(address operator) external view returns (uint256) {
         return operatorWeights[operator];
     }
+
+    function getOperatorSigningKeyAtBlock(address operator, uint256) external view returns (address) {
+        return operatorToSigning[operator];
+    }
+
+    function getLatestOperatorSigningKey(address operator) external view returns (address) {
+        return operatorToSigning[operator];
+    }
+
+    function getOperatorForSigningKeyAtBlock(address signing, uint256) external view returns (address) {
+        return signingToOperator[signing];
+    }
+
+    function getLatestOperatorForSigningKey(address signing) external view returns (address) {
+        return signingToOperator[signing];
+    }
 }
 
 contract WavsServiceManagerTest is Test {
@@ -119,6 +135,11 @@ contract WavsServiceManagerTest is Test {
         // Test initial state
         assertEq(serviceManager.quorumNumerator(), 2, "Initial quorum numerator should be 2");
         assertEq(serviceManager.quorumDenominator(), 3, "Initial quorum denominator should be 3");
+
+        address signer = mockStakeRegistry.getLatestOperatorSigningKey(operator1);
+        assertEq(signer, operator1, "Initial signer should match operator");
+        signer = mockStakeRegistry.getOperatorSigningKeyAtBlock(operator1, block.number - 1);
+        assertEq(signer, operator1, "At block query should match operator");
     }
     
     function test_validateQuorumSigned_success() public view {

--- a/contracts/eigenlayer/test/WavsServiceManager.t.sol
+++ b/contracts/eigenlayer/test/WavsServiceManager.t.sol
@@ -11,13 +11,25 @@ import {UpgradeableProxyLib} from "../script/utils/UpgradeableProxyLib.sol";
 uint256 constant OPERATOR_WEIGHT = 100; 
 
 contract MockStakeRegistry {
+    mapping(address => address) public operatorToSigning;
+    mapping(address => address) public signingToOperator;
     mapping(address => uint256) public operatorWeights;
     uint256 public totalWeight;
     
     function setOperatorWeight(address operator, uint256 weight) external {
         operatorWeights[operator] = weight;
+        // set this to self
+        operatorToSigning[operator] = operator;
+        signingToOperator[operator] = operator;
     }
-    
+
+    function setOperatorSigner(address operator, address signer) external {
+        operatorToSigning[operator] = signer;
+        address oldSigner = operatorToSigning[operator];
+        delete signingToOperator[oldSigner];
+        signingToOperator[signer] = operator;
+    }
+
     function setTotalWeight(uint256 _totalWeight) external {
         totalWeight = _totalWeight;
     }
@@ -157,6 +169,40 @@ contract WavsServiceManagerTest is Test {
         assertTrue(true, "Validation should pass with exact quorum");
     }
     
+    function test_validateQuorumSigned_explicitSigningKeys() public {
+        address signer1 = address(0x13579);
+
+        vm.startPrank(owner);
+        // Change quorum to 1 of 5, so we just test one signer
+        serviceManager.setQuorumThreshold(1, 5);
+        // Set the signing key to something else
+        mockStakeRegistry.setOperatorSigner(operator1, signer1);
+        vm.stopPrank();
+
+        // Create signature data with signer not operator
+        address[] memory signers = new address[](1);
+        bytes[] memory signatures = new bytes[](1);
+        signers[0] = signer1; // Operators registered 0x1 to 0x5
+        signatures[0] = ""; // Empty signature since we're mocking the validation
+                IWavsServiceHandler.SignatureData memory signatureData = IWavsServiceHandler.SignatureData({
+            signers: signers,
+            signatures: signatures,
+            referenceBlock: uint32(block.number) - 1
+        });
+
+        serviceManager.validate(
+            IWavsServiceHandler.Envelope({
+                eventId: bytes20(0),
+                ordering: bytes12(0),
+                payload: ""
+            }),
+            signatureData
+        );
+        
+        // Test should not revert
+        assertTrue(true, "Validation should pass when signer is set");
+    }
+
     function test_validateQuorumSigned_zero_total_weight() public {
         // Set total weight to 0, which should always fail
         mockStakeRegistry.setTotalWeight(0);

--- a/contracts/eigenlayer/test/WavsServiceManager.t.sol
+++ b/contracts/eigenlayer/test/WavsServiceManager.t.sol
@@ -229,7 +229,7 @@ contract WavsServiceManagerTest is Test {
     
     function test_validate_invalid_signature_length() public {
         // Empty operators array
-        address[] memory emptyOperators = new address[](0);
+        address[] memory emptySigners = new address[](0);
         bytes[] memory emptySignatures = new bytes[](0);
         
         vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InvalidSignature.selector));
@@ -240,7 +240,7 @@ contract WavsServiceManagerTest is Test {
                 payload: ""
             }),
             IWavsServiceHandler.SignatureData({
-                operators: emptyOperators,
+                signers: emptySigners,
                 signatures: emptySignatures,
                 referenceBlock: 1
             })
@@ -252,16 +252,16 @@ contract WavsServiceManagerTest is Test {
         uint256 numOperators,
         uint32 referenceBlockOffset
     ) internal view returns (IWavsServiceHandler.SignatureData memory) {
-        address[] memory operators = new address[](numOperators);
+        address[] memory signers = new address[](numOperators);
         bytes[] memory signatures = new bytes[](numOperators);
         
         for (uint256 i = 0; i < numOperators; i++) {
-            operators[i] = address(uint160(i + 1)); // Operators registered 0x1 to 0x5
+            signers[i] = address(uint160(i + 1)); // Operators registered 0x1 to 0x5
             signatures[i] = ""; // Empty signature since we're mocking the validation
         }
         
         return IWavsServiceHandler.SignatureData({
-            operators: operators,
+            signers: signers,
             signatures: signatures,
             referenceBlock: uint32(block.number) - 1 - referenceBlockOffset
         });

--- a/contracts/eigenlayer/test/WavsServiceManager.t.sol
+++ b/contracts/eigenlayer/test/WavsServiceManager.t.sol
@@ -24,9 +24,9 @@ contract MockStakeRegistry {
     }
 
     function setOperatorSigner(address operator, address signer) external {
-        operatorToSigning[operator] = signer;
         address oldSigner = operatorToSigning[operator];
         delete signingToOperator[oldSigner];
+        operatorToSigning[operator] = signer;
         signingToOperator[signer] = operator;
     }
 

--- a/contracts/eigenlayer/test/WavsServiceManager.t.sol
+++ b/contracts/eigenlayer/test/WavsServiceManager.t.sol
@@ -205,7 +205,7 @@ contract WavsServiceManagerTest is Test {
         bytes[] memory signatures = new bytes[](1);
         signers[0] = signer1; // Operators registered 0x1 to 0x5
         signatures[0] = ""; // Empty signature since we're mocking the validation
-                IWavsServiceHandler.SignatureData memory signatureData = IWavsServiceHandler.SignatureData({
+        IWavsServiceHandler.SignatureData memory signatureData = IWavsServiceHandler.SignatureData({
             signers: signers,
             signatures: signatures,
             referenceBlock: uint32(block.number) - 1

--- a/contracts/interfaces/IWavsServiceHandler.sol
+++ b/contracts/interfaces/IWavsServiceHandler.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 interface IWavsServiceHandler {
     struct SignatureData {
-        address[] operators;
+        address[] signers;
         bytes[] signatures;
         uint32 referenceBlock;
     }

--- a/contracts/mocks/SimpleServiceManager.sol
+++ b/contracts/mocks/SimpleServiceManager.sol
@@ -17,14 +17,14 @@ contract SimpleServiceManager is IWavsServiceManager {
     ) external view override {
         // Validate that operators are sorted in ascending byte order
         require(
-            _validateOperatorSorting(signatureData.operators),
+            _validateOperatorSorting(signatureData.signers),
             "Operators are not properly sorted"
         );
 
         // Get the total operator weight of these signatures
         uint256 totalWeight = 0;
-        for (uint256 i = 0; i < signatureData.operators.length; i++) {
-            totalWeight += operatorWeights[signatureData.operators[i]];
+        for (uint256 i = 0; i < signatureData.signers.length; i++) {
+            totalWeight += operatorWeights[signatureData.signers[i]];
         }
 
         // Check if total weight is above threshold


### PR DESCRIPTION
Fixed issue #126 
Fixed issue #129 

Update the names in SignatureData. Also fix ServiceManager.validate check to properly get operator weight when signing key is different. Should fix integration tests.