### PR TITLE
Mock emit errors

### DIFF
--- a/contracts/eigenlayer/src/WavsServiceManager.sol
+++ b/contracts/eigenlayer/src/WavsServiceManager.sol
@@ -242,7 +242,7 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
     ) internal view {
         // Avoid 0 weight ever passing this check
         if (totalWeight == 0) {
-            revert IWavsServiceManager.InsufficientQuorum();
+            revert IWavsServiceManager.InsufficientQuorumZero();
         }
         
         // Check if signedWeight >= (quorumNumerator/quorumDenominator) * totalWeight

--- a/contracts/eigenlayer/src/WavsServiceManager.sol
+++ b/contracts/eigenlayer/src/WavsServiceManager.sol
@@ -245,10 +245,12 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
             revert IWavsServiceManager.InsufficientQuorumZero();
         }
         
-        // Check if signedWeight >= (quorumNumerator/quorumDenominator) * totalWeight
-        // This is equivalent but only using division to avoid any potential overflow
-        if (signedWeight / quorumNumerator < totalWeight / quorumDenominator) {
-            revert IWavsServiceManager.InsufficientQuorum();
+        // Calculate threshold weight
+        uint256 thresholdWeight = (totalWeight * quorumNumerator) / quorumDenominator;
+        
+        // Check if signedWeight >= thresholdWeight
+        if (signedWeight < thresholdWeight) {
+            revert IWavsServiceManager.InsufficientQuorum(signedWeight, thresholdWeight, totalWeight);
         }
     }
     

--- a/contracts/eigenlayer/src/WavsServiceManager.sol
+++ b/contracts/eigenlayer/src/WavsServiceManager.sol
@@ -184,10 +184,10 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
     ) external view {
         // Input validation
         if (signatureData.signers.length == 0 || signatureData.signers.length != signatureData.signatures.length) {
-            revert IWavsServiceManager.InvalidSignature();
+            revert IWavsServiceManager.InvalidSignatureLength();
         }
         if (signatureData.referenceBlock >= block.number) {
-            revert IWavsServiceManager.InvalidSignature();
+            revert IWavsServiceManager.InvalidSignatureBlock();
         }
 
         // Create message hash

--- a/contracts/eigenlayer/test/WavsServiceManager.t.sol
+++ b/contracts/eigenlayer/test/WavsServiceManager.t.sol
@@ -228,7 +228,7 @@ contract WavsServiceManagerTest is Test {
         // Set total weight to 0, which should always fail
         mockStakeRegistry.setTotalWeight(0);
         
-        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InsufficientQuorum.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InsufficientQuorumZero.selector));
         serviceManager.validate(
             IWavsServiceHandler.Envelope({
                 eventId: bytes20(0),

--- a/contracts/eigenlayer/test/WavsServiceManager.t.sol
+++ b/contracts/eigenlayer/test/WavsServiceManager.t.sol
@@ -299,7 +299,7 @@ contract WavsServiceManagerTest is Test {
         address[] memory emptySigners = new address[](0);
         bytes[] memory emptySignatures = new bytes[](0);
         
-        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InvalidSignature.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InvalidSignatureLength.selector));
         serviceManager.validate(
             IWavsServiceHandler.Envelope({
                 eventId: bytes20(0),

--- a/contracts/eigenlayer/test/WavsServiceManager.t.sol
+++ b/contracts/eigenlayer/test/WavsServiceManager.t.sol
@@ -159,7 +159,7 @@ contract WavsServiceManagerTest is Test {
     
     function test_validateQuorumSigned_insufficient() public {
         // 2/3 of 500 is 333, so 300 should fail
-        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InsufficientQuorum.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InsufficientQuorum.selector, 300, 333, 500));
         serviceManager.validate(
             IWavsServiceHandler.Envelope({
                 eventId: bytes20(0),
@@ -259,7 +259,7 @@ contract WavsServiceManagerTest is Test {
         );
 
         // Now 200/500 (40%) should fail (needs 255)
-        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InsufficientQuorum.selector));
+        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InsufficientQuorum.selector, 200, 255, 500));
         serviceManager.validate(
             IWavsServiceHandler.Envelope({
                 eventId: bytes20(0),

--- a/contracts/interfaces/IWavsServiceManager.sol
+++ b/contracts/interfaces/IWavsServiceManager.sol
@@ -8,6 +8,9 @@ interface IWavsServiceManager {
     // ------------------------------------------------------------------------
     // Custom Errors
     // ------------------------------------------------------------------------
+    error InvalidSignatureLength();
+    error InvalidSignatureBlock();
+    error InvalidSignatureOrder();
     error InvalidSignature();
     error InsufficientQuorum();
     error InvalidQuorumParameters();

--- a/contracts/interfaces/IWavsServiceManager.sol
+++ b/contracts/interfaces/IWavsServiceManager.sol
@@ -13,7 +13,7 @@ interface IWavsServiceManager {
     error InvalidSignatureOrder();
     error InvalidSignature();
     error InsufficientQuorumZero();
-    error InsufficientQuorum();
+    error InsufficientQuorum(uint256 signerWeight, uint256 thresholdWeight, uint256 totalWeight);
     error InvalidQuorumParameters();
     
     // ------------------------------------------------------------------------

--- a/contracts/interfaces/IWavsServiceManager.sol
+++ b/contracts/interfaces/IWavsServiceManager.sol
@@ -12,6 +12,7 @@ interface IWavsServiceManager {
     error InvalidSignatureBlock();
     error InvalidSignatureOrder();
     error InvalidSignature();
+    error InsufficientQuorumZero();
     error InsufficientQuorum();
     error InvalidQuorumParameters();
     

--- a/contracts/mocks/SimpleServiceManager.sol
+++ b/contracts/mocks/SimpleServiceManager.sol
@@ -15,11 +15,16 @@ contract SimpleServiceManager is IWavsServiceManager {
         IWavsServiceHandler.Envelope calldata /* envelope */,
         IWavsServiceHandler.SignatureData calldata signatureData
     ) external view override {
-        // Validate that operators are sorted in ascending byte order
-        require(
-            _validateOperatorSorting(signatureData.signers),
-            "Operators are not properly sorted"
-        );
+        // Input validation
+        if (signatureData.signers.length == 0 || signatureData.signers.length != signatureData.signatures.length) {
+            revert IWavsServiceManager.InvalidSignature();
+        }
+        if (signatureData.referenceBlock >= block.number) {
+            revert IWavsServiceManager.InvalidSignature();
+        }
+        if (!_validateOperatorSorting(signatureData.signers)) {
+            revert IWavsServiceManager.InvalidSignature();
+        }
 
         // Get the total operator weight of these signatures
         uint256 totalWeight = 0;
@@ -27,11 +32,15 @@ contract SimpleServiceManager is IWavsServiceManager {
             totalWeight += operatorWeights[signatureData.signers[i]];
         }
 
-        // Check if total weight is above threshold
-        require(
-            totalWeight >= lastCheckpointThresholdWeight,
-            "Not enough operator weight"
-        );
+        // Avoid 0 weight ever passing this check
+        if (totalWeight == 0) {
+            revert IWavsServiceManager.InsufficientQuorum();
+        }
+
+        // Check if the total weight meets the last checkpoint threshold 
+        if (totalWeight < lastCheckpointThresholdWeight) {
+            revert IWavsServiceManager.InsufficientQuorum();
+        }
     }
 
     /**

--- a/contracts/mocks/SimpleServiceManager.sol
+++ b/contracts/mocks/SimpleServiceManager.sol
@@ -17,13 +17,13 @@ contract SimpleServiceManager is IWavsServiceManager {
     ) external view override {
         // Input validation
         if (signatureData.signers.length == 0 || signatureData.signers.length != signatureData.signatures.length) {
-            revert IWavsServiceManager.InvalidSignature();
+            revert IWavsServiceManager.InvalidSignatureLength();
         }
         if (signatureData.referenceBlock >= block.number) {
-            revert IWavsServiceManager.InvalidSignature();
+            revert IWavsServiceManager.InvalidSignatureBlock();
         }
         if (!_validateOperatorSorting(signatureData.signers)) {
-            revert IWavsServiceManager.InvalidSignature();
+            revert IWavsServiceManager.InvalidSignatureOrder();
         }
 
         // Get the total operator weight of these signatures

--- a/contracts/mocks/SimpleServiceManager.sol
+++ b/contracts/mocks/SimpleServiceManager.sol
@@ -34,7 +34,7 @@ contract SimpleServiceManager is IWavsServiceManager {
 
         // Avoid 0 weight ever passing this check
         if (totalWeight == 0) {
-            revert IWavsServiceManager.InsufficientQuorum();
+            revert IWavsServiceManager.InsufficientQuorumZero();
         }
 
         // Check if the total weight meets the last checkpoint threshold 

--- a/contracts/mocks/SimpleServiceManager.sol
+++ b/contracts/mocks/SimpleServiceManager.sol
@@ -27,19 +27,19 @@ contract SimpleServiceManager is IWavsServiceManager {
         }
 
         // Get the total operator weight of these signatures
-        uint256 totalWeight = 0;
+        uint256 signedWeight = 0;
         for (uint256 i = 0; i < signatureData.signers.length; i++) {
-            totalWeight += operatorWeights[signatureData.signers[i]];
+            signedWeight += operatorWeights[signatureData.signers[i]];
         }
 
         // Avoid 0 weight ever passing this check
-        if (totalWeight == 0) {
+        if (signedWeight == 0) {
             revert IWavsServiceManager.InsufficientQuorumZero();
         }
 
         // Check if the total weight meets the last checkpoint threshold 
-        if (totalWeight < lastCheckpointThresholdWeight) {
-            revert IWavsServiceManager.InsufficientQuorum();
+        if (signedWeight < lastCheckpointThresholdWeight) {
+            revert IWavsServiceManager.InsufficientQuorum(signedWeight, lastCheckpointThresholdWeight, lastCheckpointTotalWeight);
         }
     }
 


### PR DESCRIPTION
This makes the mock contract emit the same errors as real service manager. Also added a couple more error types so we can be more explicit in tests