### PR TITLE
112 create mirror ecdsastakeregistry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 [submodule "contracts/lib/eigenlayer-middleware"]
 	path = contracts/lib/eigenlayer-middleware
 	url = https://github.com/Lay3rLabs/eigenlayer-middleware
-	# This commit hash (5d309a7fdf12872bbe14b0852eea08fe4188166f) corresponds to wavs-1.4 branch (based on tag v1.4.0-testnet-holesky)
-	branch = 5d309a7fdf12872bbe14b0852eea08fe4188166f 
+	# This commit hash (3ea829d52c4a8cb1d26c9a6ac4807b87c70a1f47) corresponds to wavs-1.4 branch (based on tag v1.4.0-testnet-holesky)
+	branch = 3ea829d52c4a8cb1d26c9a6ac4807b87c70a1f47 

--- a/contracts/eigenlayer/script/WavsMirrorDeployer.s.sol
+++ b/contracts/eigenlayer/script/WavsMirrorDeployer.s.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/Test.sol";
+import {WavsMirrorDeploymentLib} from "./utils/WavsMirrorDeplomentLib.sol";
+import {ReadCoreLib} from "./utils/ReadCoreLib.sol";
+import {UpgradeableProxyLib} from "./utils/UpgradeableProxyLib.sol";
+import {StrategyBase} from "@eigenlayer/contracts/strategies/StrategyBase.sol";
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {StrategyFactory} from "@eigenlayer/contracts/strategies/StrategyFactory.sol";
+import {StrategyManager} from "@eigenlayer/contracts/core/StrategyManager.sol";
+
+
+import {
+    IECDSAStakeRegistryTypes,
+    IStrategy
+} from "@eigenlayer-middleware/src/interfaces/IECDSAStakeRegistry.sol";
+
+contract WavsMirrorDeployer is Script, IECDSAStakeRegistryTypes {
+    using ReadCoreLib for *;
+    using UpgradeableProxyLib for address;
+
+    address private deployer;
+    address proxyAdmin;
+    IStrategy helloWorldStrategy;
+    ReadCoreLib.DeploymentData coreDeployment;
+    WavsMirrorDeploymentLib.DeploymentData WavsMirrorDeployment;
+
+    function setUp() public virtual {
+        deployer = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
+        vm.label(deployer, "Mirror Deployer");
+    }
+
+    function run() external {
+        vm.startBroadcast(deployer);
+        proxyAdmin = UpgradeableProxyLib.deployProxyAdmin();
+
+        WavsMirrorDeployment =
+            WavsMirrorDeploymentLib.deployContracts(proxyAdmin);
+        vm.stopBroadcast();
+
+        verifyDeployment();
+        WavsMirrorDeploymentLib.writeDeploymentJson(WavsMirrorDeployment);
+    }
+
+    function verifyDeployment() internal view {
+        require(
+            WavsMirrorDeployment.stakeRegistry != address(0), "StakeRegistry address cannot be zero"
+        );
+        require(
+            WavsMirrorDeployment.WavsServiceManager != address(0),
+            "WavsServiceManager address cannot be zero"
+        );
+        require(proxyAdmin != address(0), "ProxyAdmin address cannot be zero");
+    }
+}

--- a/contracts/eigenlayer/script/WavsMirrorDeployer.s.sol
+++ b/contracts/eigenlayer/script/WavsMirrorDeployer.s.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {Script} from "forge-std/Script.sol";
 import {console2} from "forge-std/Test.sol";
-import {WavsMirrorDeploymentLib} from "./utils/WavsMirrorDeplomentLib.sol";
+import {WavsMirrorDeploymentLib} from "./utils/WavsMirrorDeploymentLib.sol";
 import {ReadCoreLib} from "./utils/ReadCoreLib.sol";
 import {UpgradeableProxyLib} from "./utils/UpgradeableProxyLib.sol";
 import {StrategyBase} from "@eigenlayer/contracts/strategies/StrategyBase.sol";

--- a/contracts/eigenlayer/script/utils/WavsMirrorDeplomentLib.sol
+++ b/contracts/eigenlayer/script/utils/WavsMirrorDeplomentLib.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+import {MirrorStakeRegistry} from "../../src/MirrorStakeRegistry.sol";
+import {WavsServiceManager} from "../../src/WavsServiceManager.sol";
+import {IDelegationManager} from "@eigenlayer/contracts/interfaces/IDelegationManager.sol";
+import {
+    IECDSAStakeRegistryTypes,
+    IStrategy
+} from "@eigenlayer-middleware/src/interfaces/IECDSAStakeRegistry.sol";
+import {UpgradeableProxyLib} from "./UpgradeableProxyLib.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+library WavsMirrorDeploymentLib {
+    using stdJson for *;
+    using Strings for *;
+    using UpgradeableProxyLib for address;
+
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    struct DeploymentData {
+        address WavsServiceManager;
+        address stakeRegistry;
+    }
+
+    function deployContracts(
+        address proxyAdmin
+    ) internal returns (DeploymentData memory) {
+        DeploymentData memory result;
+
+        // use an empty quorum just to fill the sapace, we don't use it internally
+        IECDSAStakeRegistryTypes.StrategyParams[] memory strategies = new IECDSAStakeRegistryTypes.StrategyParams[](0);
+        IECDSAStakeRegistryTypes.Quorum memory quorum = IECDSAStakeRegistryTypes.Quorum({strategies: strategies});
+
+        // First, deploy upgradeable proxy contracts that will point to the implementations.
+        result.WavsServiceManager = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        result.stakeRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        // Deploy the implementation contracts, using the proxy contracts as inputs
+        address stakeRegistryImpl =
+            address(new MirrorStakeRegistry());
+        // Use 0 address for contracts we don't use
+        address WavsServiceManagerImpl = address(
+            new WavsServiceManager(
+                address(0),
+                result.stakeRegistry,
+                address(0),
+                address(0),
+                address(0)
+            )
+        );
+        // Upgrade contracts
+        bytes memory stakeRegistryUpgradeCall = abi.encodeCall(
+            MirrorStakeRegistry.initialize, (result.WavsServiceManager, 100, quorum) // TODO: dynamically update threshold (?)
+        );
+        bytes memory WavsServiceManagerUpgradeCall = abi.encodeCall(
+            WavsServiceManager.initialize, (msg.sender, msg.sender)
+        );
+        UpgradeableProxyLib.upgradeAndCall(result.stakeRegistry, stakeRegistryImpl, stakeRegistryUpgradeCall);
+        UpgradeableProxyLib.upgradeAndCall(result.WavsServiceManager, WavsServiceManagerImpl, WavsServiceManagerUpgradeCall);
+
+        // TODO: This is incredibly stupid, 
+        // when we implement out own stake registry, pass owner as an argument
+        bytes memory stakeRegistryOwnerUpgradeCall = abi.encodeCall(
+            Ownable.transferOwnership, (msg.sender)
+        );
+        UpgradeableProxyLib.upgradeAndCall(result.stakeRegistry, stakeRegistryImpl, stakeRegistryOwnerUpgradeCall);
+
+        return result;
+    }
+
+    function readDeploymentJson(
+        uint256 chainId
+    ) internal returns (DeploymentData memory) {
+        return readDeploymentJson("deployments/wavs-mirror/", chainId);
+    }
+
+    function readDeploymentJson(
+        string memory directoryPath,
+        uint256 chainId
+    ) internal returns (DeploymentData memory) {
+        string memory fileName = string.concat(directoryPath, vm.toString(chainId), ".json");
+
+        require(vm.exists(fileName), "Deployment file does not exist");
+
+        string memory json = vm.readFile(fileName);
+
+        DeploymentData memory data;
+        /// TODO: 2 Step for reading deployment json.  Read to the core and the AVS data
+        data.WavsServiceManager = json.readAddress(".contracts.WavsServiceManager");
+        data.stakeRegistry = json.readAddress(".contracts.stakeRegistry");
+        
+        return data;
+    }
+
+    /// write to default output path
+    function writeDeploymentJson(
+        DeploymentData memory data
+    ) internal {
+        writeDeploymentJson("deployments/wavs-mirror/", block.chainid, data);
+    }
+
+    function writeDeploymentJson(
+        string memory outputPath,
+        uint256 chainId,
+        DeploymentData memory data
+    ) internal {
+        address proxyAdmin =
+            address(UpgradeableProxyLib.getProxyAdmin(data.WavsServiceManager));
+
+        string memory deploymentData = _generateDeploymentJson(data, proxyAdmin);
+
+        string memory fileName = string.concat(outputPath, vm.toString(chainId), ".json");
+        if (!vm.exists(outputPath)) {
+            vm.createDir(outputPath, true);
+        }
+
+        vm.writeFile(fileName, deploymentData);
+        console2.log("Deployment artifacts written to:", fileName);
+    }
+
+    function _generateDeploymentJson(
+        DeploymentData memory data,
+        address proxyAdmin
+    ) private view returns (string memory) {
+        return string.concat(
+            '{',
+                '"lastUpdate":{',
+                    '"timestamp":"', vm.toString(block.timestamp), '",',
+                    '"block_number":"', vm.toString(block.number), '"',
+                '},',
+                '"addresses":', 
+                    _generateContractsJson(data, proxyAdmin),
+            '}'
+        );
+    }
+
+    function _generateContractsJson(
+        DeploymentData memory data,
+        address proxyAdmin
+    ) private view returns (string memory) {
+        return string.concat(
+            '{"proxyAdmin":"',
+            proxyAdmin.toHexString(),
+            '","WavsServiceManager":"',
+            data.WavsServiceManager.toHexString(),
+            '","WavsServiceManagerImpl":"',
+            data.WavsServiceManager.getImplementation().toHexString(),
+            '","stakeRegistry":"',
+            data.stakeRegistry.toHexString(),
+            '","stakeRegistryImpl":"',
+            data.stakeRegistry.getImplementation().toHexString(),
+            '"}'
+        );
+    }
+}

--- a/contracts/eigenlayer/script/utils/WavsMirrorDeploymentLib.sol
+++ b/contracts/eigenlayer/script/utils/WavsMirrorDeploymentLib.sol
@@ -36,8 +36,14 @@ library WavsMirrorDeploymentLib {
     ) internal returns (DeploymentData memory) {
         DeploymentData memory result;
 
-        // use an empty quorum just to fill the sapace, we don't use it internally
-        IECDSAStakeRegistryTypes.StrategyParams[] memory strategies = new IECDSAStakeRegistryTypes.StrategyParams[](0);
+        // use an mock quorum so checks pass, we don't use it internally
+        IStrategy mockStrategyInstance = IStrategy(address(1)); // Using address(1) instead of address(0)
+        IECDSAStakeRegistryTypes.StrategyParams memory strategyParams = IECDSAStakeRegistryTypes.StrategyParams({
+            strategy: mockStrategyInstance,
+            multiplier: 10000 // 100% in basis points
+        });
+        IECDSAStakeRegistryTypes.StrategyParams[] memory strategies = new IECDSAStakeRegistryTypes.StrategyParams[](1);
+        strategies[0] = strategyParams;
         IECDSAStakeRegistryTypes.Quorum memory quorum = IECDSAStakeRegistryTypes.Quorum({strategies: strategies});
 
         // First, deploy upgradeable proxy contracts that will point to the implementations.

--- a/contracts/eigenlayer/src/MirrorStakeRegistry.sol
+++ b/contracts/eigenlayer/src/MirrorStakeRegistry.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {IDelegationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {ECDSAStakeRegistry, IECDSAStakeRegistryTypes} from "@eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {ISignatureUtilsMixinTypes} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
+
+/**
+ * @title Mirror Stake Registry
+ * @notice A mock implementation of ECDSAStakeRegistry that doesn't have public methods to update stake or register operators
+ * @dev This contract overrides external registration methods to revert and provides an owner-only method to set lookups
+ */
+contract MirrorStakeRegistry is ECDSAStakeRegistry {
+    /// @notice Error thrown when attempting to register an operator through the public method
+    error RegistrationNotSupported();
+    
+    /// @notice Error thrown when attempting to deregister an operator through the public method
+    error DeregistrationNotSupported();
+    
+    /// @notice Error thrown when attempting to update an operator's signing key through the public method
+    error SigningKeyUpdateNotSupported();
+    
+    /// @notice Error thrown when attempting to update operators through the public method
+    error OperatorUpdateNotSupported();
+    
+    /// @notice Error thrown when attempting to update operators for quorum through the public method
+    error QuorumOperatorUpdateNotSupported();
+
+    /// @dev Constructor to create MirrorStakeRegistry.
+    constructor() ECDSAStakeRegistry(IDelegationManager(address(0))) {
+
+    }
+
+/*
+TODO: overrdie this
+        /// @notice Initializes the contract with the given parameters.
+    /// @param _serviceManager The address of the service manager.
+    /// @param thresholdWeight The threshold weight in basis points.
+    /// @param quorum The quorum struct containing the details of the quorum thresholds.
+    function initialize(
+        address _serviceManager,
+        uint256 thresholdWeight,
+        IECDSAStakeRegistryTypes.Quorum memory quorum
+    ) external initializer {
+        // TODO
+        // __ECDSAStakeRegistry_init(_serviceManager, thresholdWeight, quorum);
+    }
+*/
+
+    /// @notice Override the registerOperatorWithSignature method to revert
+    /// @dev This operation is not supported in the mock implementation
+    function registerOperatorWithSignature(
+        ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory,
+        address
+    ) external override {
+        revert RegistrationNotSupported();
+    }
+
+    /// @notice Override the deregisterOperator method to revert
+    /// @dev This operation is not supported in the mock implementation
+    function deregisterOperator() external override {
+        revert DeregistrationNotSupported();
+    }
+
+    /// @notice Override the updateOperatorSigningKey method to revert
+    /// @dev This operation is not supported in the mock implementation
+    function updateOperatorSigningKey(
+        address
+    ) external override {
+        revert SigningKeyUpdateNotSupported();
+    }
+
+    /// @notice Override the updateOperators method to revert
+    /// @dev This operation is not supported in the mock implementation
+    function updateOperators(
+        address[] memory
+    ) external override {
+        revert OperatorUpdateNotSupported();
+    }
+    
+    /// @notice Override the updateOperatorsForQuorum method to revert
+    /// @dev This operation is not supported in the mock implementation
+    function updateOperatorsForQuorum(
+        address[][] memory,
+        bytes memory
+    ) external override {
+        revert QuorumOperatorUpdateNotSupported();
+    }
+
+    /// @dev This operation is not supported in the mock implementation
+    function updateQuorumConfig(
+         IECDSAStakeRegistryTypes.Quorum memory quorum,
+         address[] memory operators
+    ) external override onlyOwner {
+        revert QuorumOperatorUpdateNotSupported();
+    }
+
+    /// @dev This operation is not supported in the mock implementation
+    function updateMinimumWeight(
+         uint256 newMinimumWeight,
+         address[] memory operators
+    ) external override onlyOwner {
+        revert OperatorUpdateNotSupported();
+    }
+
+    /// @dev This operation is not supported in the mock implementation
+    function updateStakeThreshold(
+         uint256 thresholdWeight
+    ) external override onlyOwner {
+        revert OperatorUpdateNotSupported();
+    }
+
+    /// @inheritdoc ECDSAStakeRegistry
+    function getOperatorWeight(
+        address operator
+    ) public view override returns (uint256) {
+        // TODO
+        return 0;
+    }
+
+    /**
+     * @notice Sets the operator weight and signing key lookup
+     * @dev This is the owner-only entrypoint to set all lookups (weights and operator <-> signing key lookups)
+     * @param operator The operator address
+     * @param signingKey The signing key to associate with the operator
+     * @param weight The weight to assign to the operator
+     */
+    function setOperatorDetails(
+        address operator,
+        address signingKey,
+        uint256 weight
+    ) external onlyOwner {
+        // This is a no-op implementation as specified in the requirements
+        // It will be expanded in the final implementation
+    }
+
+    /**
+     * @notice Batch sets multiple operator details at once
+     * @dev This is the owner-only entrypoint to set multiple operator lookups at once
+     * @param operators Array of operator addresses
+     * @param signingKeys Array of signing keys corresponding to the operators
+     * @param weights Array of weights corresponding to the operators
+     */
+    function batchSetOperatorDetails(
+        address[] calldata operators,
+        address[] calldata signingKeys,
+        uint256[] calldata weights
+    ) external onlyOwner {
+        // This is a no-op implementation as specified in the requirements
+        // It will be expanded in the final implementation
+    }
+}

--- a/contracts/eigenlayer/src/MirrorStakeRegistry.sol
+++ b/contracts/eigenlayer/src/MirrorStakeRegistry.sol
@@ -6,6 +6,8 @@ import {IDelegationManager} from
 import {ECDSAStakeRegistry, IECDSAStakeRegistryTypes} from "@eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {ISignatureUtilsMixinTypes} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
+import {CheckpointsUpgradeable} from
+    "@openzeppelin-upgrades/contracts/utils/CheckpointsUpgradeable.sol";
 
 /**
  * @title Mirror Stake Registry
@@ -13,6 +15,8 @@ import {ISignatureUtilsMixinTypes} from "eigenlayer-contracts/src/contracts/inte
  * @dev This contract overrides external registration methods to revert and provides an owner-only method to set lookups
  */
 contract MirrorStakeRegistry is ECDSAStakeRegistry {
+    using CheckpointsUpgradeable for CheckpointsUpgradeable.History;
+
     /// @notice Error thrown when attempting to register an operator through the public method
     error RegistrationNotSupported();
     
@@ -28,14 +32,15 @@ contract MirrorStakeRegistry is ECDSAStakeRegistry {
     /// @notice Error thrown when attempting to update operators for quorum through the public method
     error QuorumOperatorUpdateNotSupported();
 
+    /// @notice Error thrown when array lengths don't match in batch operations
+    error InvalidArrayLengths();
+
     /// @dev Constructor to create MirrorStakeRegistry.
     constructor() ECDSAStakeRegistry(IDelegationManager(address(0))) {
-
+        // Empty constructor
     }
 
-/*
-TODO: overrdie this
-        /// @notice Initializes the contract with the given parameters.
+    /// @notice Initializes the contract with the given parameters.
     /// @param _serviceManager The address of the service manager.
     /// @param thresholdWeight The threshold weight in basis points.
     /// @param quorum The quorum struct containing the details of the quorum thresholds.
@@ -43,11 +48,11 @@ TODO: overrdie this
         address _serviceManager,
         uint256 thresholdWeight,
         IECDSAStakeRegistryTypes.Quorum memory quorum
-    ) external initializer {
-        // TODO
-        // __ECDSAStakeRegistry_init(_serviceManager, thresholdWeight, quorum);
+    ) external override initializer {
+        // We can't override initialize since it's not virtual in the parent contract
+        // But we can still call the internal initialization function
+        __ECDSAStakeRegistry_init(_serviceManager, thresholdWeight, quorum);
     }
-*/
 
     /// @notice Override the registerOperatorWithSignature method to revert
     /// @dev This operation is not supported in the mock implementation
@@ -91,23 +96,23 @@ TODO: overrdie this
 
     /// @dev This operation is not supported in the mock implementation
     function updateQuorumConfig(
-         IECDSAStakeRegistryTypes.Quorum memory quorum,
-         address[] memory operators
+         IECDSAStakeRegistryTypes.Quorum memory,
+         address[] memory
     ) external override onlyOwner {
         revert QuorumOperatorUpdateNotSupported();
     }
 
     /// @dev This operation is not supported in the mock implementation
     function updateMinimumWeight(
-         uint256 newMinimumWeight,
-         address[] memory operators
+         uint256,
+         address[] memory
     ) external override onlyOwner {
         revert OperatorUpdateNotSupported();
     }
 
     /// @dev This operation is not supported in the mock implementation
     function updateStakeThreshold(
-         uint256 thresholdWeight
+         uint256
     ) external override onlyOwner {
         revert OperatorUpdateNotSupported();
     }
@@ -116,8 +121,7 @@ TODO: overrdie this
     function getOperatorWeight(
         address operator
     ) public view override returns (uint256) {
-        // TODO
-        return 0;
+        return _operatorWeightHistory[operator].latest();
     }
 
     /**
@@ -132,8 +136,7 @@ TODO: overrdie this
         address signingKey,
         uint256 weight
     ) external onlyOwner {
-        // This is a no-op implementation as specified in the requirements
-        // It will be expanded in the final implementation
+        _setOperatorDetails(operator, signingKey, weight);
     }
 
     /**
@@ -148,7 +151,78 @@ TODO: overrdie this
         address[] calldata signingKeys,
         uint256[] calldata weights
     ) external onlyOwner {
-        // This is a no-op implementation as specified in the requirements
-        // It will be expanded in the final implementation
+        // Validate array lengths match
+        if (operators.length != signingKeys.length || operators.length != weights.length) {
+            revert InvalidArrayLengths();
+        }
+
+        uint256 length = operators.length;
+        for (uint256 i = 0; i < length; i++) {
+            _setOperatorDetails(operators[i], signingKeys[i], weights[i]);
+        }
+    }
+
+    /**
+     * @dev Internal function to set operator details
+     * @param operator The operator address
+     * @param signingKey The signing key to associate with the operator
+     * @param weight The weight to assign to the operator
+     */
+    /**
+     * @notice Returns the service manager address
+     * @return The address of the service manager
+     */
+    function serviceManager() external view returns (address) {
+        return _serviceManager;
+    }
+
+    function _setOperatorDetails(
+        address operator,
+        address signingKey,
+        uint256 weight
+    ) internal {
+        // Get the current weight of the operator
+        uint256 currentWeight = _operatorWeightHistory[operator].latest();
+        
+        // Calculate the weight delta
+        int256 weightDelta = int256(weight) - int256(currentWeight);
+        
+        // Update the operator weight
+        _operatorWeightHistory[operator].push(weight);
+        
+        // Update the total weight
+        (uint256 oldTotalWeight, uint256 newTotalWeight) = _updateTotalWeight(weightDelta);
+        
+        // Get the current signing key for the operator
+        address currentSigningKey = address(uint160(_operatorSigningKeyHistory[operator].latest()));
+        
+        // If the signing key is different, update the mappings
+        if (currentSigningKey != signingKey) {
+            // Remove the old signing key mapping if it exists
+            if (currentSigningKey != address(0)) {
+                // Clear the old signing key to operator mapping in history
+                _signingKeyToOperatorHistory[currentSigningKey].push(0); // Set to 0 to indicate no operator
+            }
+            
+            // Set the new signing key mapping
+            _operatorSigningKeyHistory[operator].push(uint256(uint160(signingKey)));
+            _signingKeyToOperatorHistory[signingKey].push(uint256(uint160(operator)));
+        }
+        
+        // Mark the operator as registered
+        _operatorRegistered[operator] = true;
+        
+        // Emit events
+        emit OperatorWeightUpdated(operator, currentWeight, weight);
+        emit TotalWeightUpdated(oldTotalWeight, newTotalWeight);
+        
+        if (currentSigningKey != signingKey) {
+            emit SigningKeyUpdate(
+                operator,
+                block.number,
+                signingKey,
+                currentSigningKey
+            );
+        }
     }
 }

--- a/contracts/eigenlayer/test/MirrorStakeRegistry.t.sol
+++ b/contracts/eigenlayer/test/MirrorStakeRegistry.t.sol
@@ -7,6 +7,8 @@ import {IECDSAStakeRegistryTypes} from "@eigenlayer-middleware/src/unaudited/ECD
 import {ISignatureUtilsMixinTypes} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {IERC1271Upgradeable} from "@openzeppelin-upgrades/contracts/interfaces/IERC1271Upgradeable.sol";
+import {SignatureCheckerUpgradeable} from "@openzeppelin-upgrades/contracts/utils/cryptography/SignatureCheckerUpgradeable.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 contract MirrorStakeRegistryTest is Test {
     MirrorStakeRegistry public registry;
@@ -333,8 +335,80 @@ contract MirrorStakeRegistryTest is Test {
         vm.stopPrank();
     }
 
-    // Test isValidSignature functionality
+    // Private keys for signing (using deterministic keys for testing)
+    uint256 private constant SIGNER_PK1 = 1;
+    uint256 private constant SIGNER_PK2 = 2;
+    uint256 private constant SIGNER_PK3 = 3;
+    
+    /**
+     * @notice Helper function to sort signers and their corresponding signatures in ascending order by signer address
+     * @dev ECDSAStakeRegistry requires signers to be sorted in ascending order
+     * @param signers Array of signer addresses
+     * @param signatures Array of signatures that correspond to signers at the same index
+     */
+    function sortSignersAndSignatures(
+        address[] memory signers,
+        bytes[] memory signatures
+    ) internal pure {
+        // Simple bubble sort since we're working with small arrays
+        uint256 length = signers.length;
+        for (uint256 i = 0; i < length - 1; i++) {
+            for (uint256 j = 0; j < length - i - 1; j++) {
+                if (signers[j] > signers[j + 1]) {
+                    // Swap signers
+                    address tempAddr = signers[j];
+                    signers[j] = signers[j + 1];
+                    signers[j + 1] = tempAddr;
+                    
+                    // Swap corresponding signatures
+                    bytes memory tempSig = signatures[j];
+                    signatures[j] = signatures[j + 1];
+                    signatures[j + 1] = tempSig;
+                }
+            }
+        }
+    }
+    
+    /**
+     * @notice Helper function to generate an ECDSA signature using a private key
+     * @param privateKey The private key to sign with
+     * @param digest The message hash to sign
+     * @return The signature in bytes format ready for validation
+     */
+    function generateSignature(
+        uint256 privateKey,
+        bytes32 digest
+    ) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+    
+    /**
+     * @notice Helper function to verify that signatures can be recovered to the expected signers
+     * @param digest Message hash that was signed
+     * @param signers Array of signer addresses (should be sorted)
+     * @param signatures Array of signatures corresponding to signers
+     */
+    function verifySignatures(
+        bytes32 digest,
+        address[] memory signers,
+        bytes[] memory signatures
+    ) internal pure {
+        require(signers.length == signatures.length, "Arrays length mismatch");
+        
+        for (uint256 i = 0; i < signers.length; i++) {
+            address recovered = ECDSA.recover(digest, signatures[i]);
+            require(recovered == signers[i], "Signature recovery failed");
+        }
+    }
+    
+    // Test isValidSignature functionality with real signatures
     function test_isValidSignature() public {
+        // Generate signing keys from private keys
+        signingKey1 = vm.addr(SIGNER_PK1);
+        signingKey2 = vm.addr(SIGNER_PK2);
+        signingKey3 = vm.addr(SIGNER_PK3);
+                
         vm.startPrank(owner);
         
         // Set up operators with weights
@@ -356,6 +430,7 @@ contract MirrorStakeRegistryTest is Test {
         
         // Batch set operator details
         registry.batchSetOperatorDetails(operators, signingKeys, weights);
+        vm.stopPrank();
         
         // Create a message to sign
         bytes32 digest = keccak256("test message");
@@ -363,50 +438,40 @@ contract MirrorStakeRegistryTest is Test {
         // Roll to the next block to make the checkpoint available
         vm.roll(block.number + 1);
         
-        // Create signature data - ECDSAStakeRegistry.isValidSignature expects (address[] signers, bytes[] signatures, uint32 referenceBlock)
-        // The signers should be the signing keys, not the operators
-        address[] memory signers = new address[](3); // Include all three signing keys to meet the threshold
+        // Create signature data for all signing keys
+        address[] memory signers = new address[](3);
         bytes[] memory signatures = new bytes[](3);
         uint32 referenceBlock = uint32(block.number - 1); // Use the previous block as reference
         
-        // Use all signing keys to meet the threshold weight
+        // Add signing keys to signers array
         signers[0] = signingKey1;
         signers[1] = signingKey2;
         signers[2] = signingKey3;
+                
+        // Generate actual signatures using the private keys
+        signatures[0] = generateSignature(SIGNER_PK1, digest);
+        signatures[1] = generateSignature(SIGNER_PK2, digest);
+        signatures[2] = generateSignature(SIGNER_PK3, digest);
+
+        // Sort the signers and signatures arrays to ensure signers are in ascending order
+        // ECDSAStakeRegistry requires this for validation
+        sortSignersAndSignatures(signers, signatures);
         
-        // Mock signatures (in a real scenario these would be valid signatures)
-        signatures[0] = abi.encodePacked(bytes32(0), bytes32(0), uint8(27));
-        signatures[1] = abi.encodePacked(bytes32(0), bytes32(0), uint8(28));
-        signatures[2] = abi.encodePacked(bytes32(0), bytes32(0), uint8(29));
+        // Verify signers are properly sorted
+        for (uint256 i = 0; i < signers.length - 1; i++) {
+            assertTrue(signers[i] < signers[i + 1], "Signers not properly sorted");
+        }
+
+        // Verify our signatures are valid and match the expected signers
+        verifySignatures(digest, signers, signatures);
         
         // Encode the signature data as expected by isValidSignature
         bytes memory signatureData = abi.encode(signers, signatures, referenceBlock);
         
-        // Mock the signature verification for all signing keys
-        vm.mockCall(
-            signingKey1,
-            abi.encodeWithSelector(IERC1271Upgradeable.isValidSignature.selector, digest, signatures[0]),
-            abi.encode(IERC1271Upgradeable.isValidSignature.selector)
-        );
-        
-        vm.mockCall(
-            signingKey2,
-            abi.encodeWithSelector(IERC1271Upgradeable.isValidSignature.selector, digest, signatures[1]),
-            abi.encode(IERC1271Upgradeable.isValidSignature.selector)
-        );
-        
-        vm.mockCall(
-            signingKey3,
-            abi.encodeWithSelector(IERC1271Upgradeable.isValidSignature.selector, digest, signatures[2]),
-            abi.encode(IERC1271Upgradeable.isValidSignature.selector)
-        );
-        
-        // Call isValidSignature
+        // Call isValidSignature with real signatures
         bytes4 result = registry.isValidSignature(digest, signatureData);
         
         // Verify the result
         assertEq(result, IERC1271Upgradeable.isValidSignature.selector, "isValidSignature should return the correct selector");
-        
-        vm.stopPrank();
     }
 }

--- a/contracts/eigenlayer/test/MirrorStakeRegistry.t.sol
+++ b/contracts/eigenlayer/test/MirrorStakeRegistry.t.sol
@@ -19,6 +19,9 @@ contract MirrorStakeRegistryTest is Test {
     address public signingKey1;
     address public signingKey2;
     address public signingKey3;
+    uint256 public privateKey1;
+    uint256 public privateKey2;
+    uint256 public privateKey3;
     address public serviceManager;
     // these should sum to around 9,0000 (so 2/3 can pass)
     uint256 public constant WEIGHT_1 = 1500;
@@ -31,9 +34,12 @@ contract MirrorStakeRegistryTest is Test {
         operator1 = address(0x1);
         operator2 = address(0x2);
         operator3 = address(0x3);
-        signingKey1 = address(0x11);
-        signingKey2 = address(0x22);
-        signingKey3 = address(0x33);
+        privateKey1 = 0x11;
+        privateKey2 = 0x22;
+        privateKey3 = 0x33;
+        signingKey1 = vm.addr(privateKey1);
+        signingKey2 = vm.addr(privateKey2);
+        signingKey3 = vm.addr(privateKey3);
         serviceManager = address(0x456);
 
         // Deploy the MirrorStakeRegistry contract
@@ -334,11 +340,6 @@ contract MirrorStakeRegistryTest is Test {
         
         vm.stopPrank();
     }
-
-    // Private keys for signing (using deterministic keys for testing)
-    uint256 private constant SIGNER_PK1 = 1;
-    uint256 private constant SIGNER_PK2 = 2;
-    uint256 private constant SIGNER_PK3 = 3;
     
     /**
      * @notice Helper function to sort signers and their corresponding signatures in ascending order by signer address
@@ -403,12 +404,7 @@ contract MirrorStakeRegistryTest is Test {
     }
     
     // Test isValidSignature functionality with real signatures
-    function test_isValidSignature() public {
-        // Generate signing keys from private keys
-        signingKey1 = vm.addr(SIGNER_PK1);
-        signingKey2 = vm.addr(SIGNER_PK2);
-        signingKey3 = vm.addr(SIGNER_PK3);
-                
+    function test_isValidSignature() public {                
         vm.startPrank(owner);
         
         // Set up operators with weights
@@ -449,9 +445,9 @@ contract MirrorStakeRegistryTest is Test {
         signers[2] = signingKey3;
                 
         // Generate actual signatures using the private keys
-        signatures[0] = generateSignature(SIGNER_PK1, digest);
-        signatures[1] = generateSignature(SIGNER_PK2, digest);
-        signatures[2] = generateSignature(SIGNER_PK3, digest);
+        signatures[0] = generateSignature(privateKey1, digest);
+        signatures[1] = generateSignature(privateKey2, digest);
+        signatures[2] = generateSignature(privateKey3, digest);
 
         // Sort the signers and signatures arrays to ensure signers are in ascending order
         // ECDSAStakeRegistry requires this for validation

--- a/contracts/eigenlayer/test/MirrorStakeRegistry.t.sol
+++ b/contracts/eigenlayer/test/MirrorStakeRegistry.t.sol
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import "forge-std/Test.sol";
+import {MirrorStakeRegistry} from "../src/MirrorStakeRegistry.sol";
+import {IECDSAStakeRegistryTypes} from "@eigenlayer-middleware/src/unaudited/ECDSAStakeRegistryStorage.sol";
+import {ISignatureUtilsMixinTypes} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtilsMixin.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {IERC1271Upgradeable} from "@openzeppelin-upgrades/contracts/interfaces/IERC1271Upgradeable.sol";
+
+contract MirrorStakeRegistryTest is Test {
+    MirrorStakeRegistry public registry;
+    address public owner;
+    address public operator1;
+    address public operator2;
+    address public operator3;
+    address public signingKey1;
+    address public signingKey2;
+    address public signingKey3;
+    address public serviceManager;
+    // these should sum to around 9,0000 (so 2/3 can pass)
+    uint256 public constant WEIGHT_1 = 1500;
+    uint256 public constant WEIGHT_2 = 3000;
+    uint256 public constant WEIGHT_3 = 4500;
+
+    function setUp() public {
+        // Set up test addresses
+        owner = address(0x123);
+        operator1 = address(0x1);
+        operator2 = address(0x2);
+        operator3 = address(0x3);
+        signingKey1 = address(0x11);
+        signingKey2 = address(0x22);
+        signingKey3 = address(0x33);
+        serviceManager = address(0x456);
+
+        // Deploy the MirrorStakeRegistry contract
+        vm.startPrank(owner);
+        registry = new MirrorStakeRegistry();
+        
+        // Initialize the registry with a service manager and quorum settings
+        // Create a strategy with a non-zero address to avoid the NotSorted error
+        // The ECDSAStakeRegistry requires strategies to be sorted by address in ascending order
+        IStrategy mockStrategyInstance = IStrategy(address(1)); // Using address(1) instead of address(0)
+        
+        // Create the strategy params
+        IECDSAStakeRegistryTypes.StrategyParams memory strategyParams = IECDSAStakeRegistryTypes.StrategyParams({
+            strategy: mockStrategyInstance,
+            multiplier: 10000 // 100% in basis points
+        });
+        
+        // Create the strategies array with one strategy
+        IECDSAStakeRegistryTypes.StrategyParams[] memory strategies = new IECDSAStakeRegistryTypes.StrategyParams[](1);
+        strategies[0] = strategyParams;
+        
+        // Create the quorum with the strategies
+        IECDSAStakeRegistryTypes.Quorum memory quorum = IECDSAStakeRegistryTypes.Quorum({strategies: strategies});
+        
+        registry.initialize(serviceManager, 6667, quorum); // 2/3 threshold (6667 basis points)
+        vm.stopPrank();
+    }
+
+    // Test that the contract is properly initialized
+    function test_initialization() public {
+        assertEq(registry.owner(), owner, "Owner should be set correctly");
+        assertEq(address(registry.serviceManager()), serviceManager, "Service manager should be set correctly");
+    }
+
+    // Test that public registration methods revert as expected
+    function test_registrationMethodsRevert() public {
+        // Test registerOperatorWithSignature reverts
+        ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory sig;
+        vm.expectRevert(MirrorStakeRegistry.RegistrationNotSupported.selector);
+        registry.registerOperatorWithSignature(sig, signingKey1);
+
+        // Test deregisterOperator reverts
+        vm.expectRevert(MirrorStakeRegistry.DeregistrationNotSupported.selector);
+        registry.deregisterOperator();
+
+        // Test updateOperatorSigningKey reverts
+        vm.expectRevert(MirrorStakeRegistry.SigningKeyUpdateNotSupported.selector);
+        registry.updateOperatorSigningKey(signingKey1);
+
+        // Test updateOperators reverts
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+        vm.expectRevert(MirrorStakeRegistry.OperatorUpdateNotSupported.selector);
+        registry.updateOperators(operators);
+
+        // Test updateOperatorsForQuorum reverts
+        address[][] memory operatorsArray = new address[][](1);
+        operatorsArray[0] = operators;
+        bytes memory extraData = "";
+        vm.expectRevert(MirrorStakeRegistry.QuorumOperatorUpdateNotSupported.selector);
+        registry.updateOperatorsForQuorum(operatorsArray, extraData);
+    }
+
+    // Test that owner-only configuration methods revert as expected
+    function test_ownerConfigMethodsRevert() public {
+        vm.startPrank(owner);
+        
+        // Test updateQuorumConfig reverts
+        IECDSAStakeRegistryTypes.StrategyParams[] memory strategyParamsArray = new IECDSAStakeRegistryTypes.StrategyParams[](0);
+        IECDSAStakeRegistryTypes.Quorum memory quorum = IECDSAStakeRegistryTypes.Quorum({
+            strategies: strategyParamsArray
+        });
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+        vm.expectRevert(MirrorStakeRegistry.QuorumOperatorUpdateNotSupported.selector);
+        registry.updateQuorumConfig(quorum, operators);
+
+        // Test updateMinimumWeight reverts
+        vm.expectRevert(MirrorStakeRegistry.OperatorUpdateNotSupported.selector);
+        registry.updateMinimumWeight(200, operators);
+
+        // Test updateStakeThreshold reverts
+        vm.expectRevert(MirrorStakeRegistry.OperatorUpdateNotSupported.selector);
+        registry.updateStakeThreshold(7000);
+        
+        vm.stopPrank();
+    }
+
+    // Test that non-owners cannot call owner-only methods
+    function test_onlyOwnerRestriction() public {
+        vm.startPrank(address(0x999)); // Not the owner
+        
+        // Test setOperatorDetails reverts for non-owners
+        vm.expectRevert("Ownable: caller is not the owner");
+        registry.setOperatorDetails(operator1, signingKey1, WEIGHT_1);
+
+        // Test batchSetOperatorDetails reverts for non-owners
+        address[] memory operators = new address[](1);
+        address[] memory signingKeys = new address[](1);
+        uint256[] memory weights = new uint256[](1);
+        operators[0] = operator1;
+        signingKeys[0] = signingKey1;
+        weights[0] = WEIGHT_1;
+        
+        vm.expectRevert("Ownable: caller is not the owner");
+        registry.batchSetOperatorDetails(operators, signingKeys, weights);
+        
+        vm.stopPrank();
+    }
+
+    // Test setting operator details by the owner
+    function test_setOperatorDetails() public {
+        vm.startPrank(owner);
+        
+        // Set operator details
+        registry.setOperatorDetails(operator1, signingKey1, WEIGHT_1);
+        
+        // Verify the operator weight is set correctly
+        assertEq(registry.getOperatorWeight(operator1), WEIGHT_1, "Operator weight should be set correctly");
+        
+        // Verify the signing key is associated with the operator
+        assertEq(registry.getLatestOperatorSigningKey(operator1), signingKey1, "Signing key should be set correctly");
+        
+        // Verify the operator is associated with the signing key
+        assertEq(registry.getLatestOperatorForSigningKey(signingKey1), operator1, "Operator should be associated with signing key");
+        
+        vm.stopPrank();
+    }
+
+    // Test batch setting operator details by the owner
+    function test_batchSetOperatorDetails() public {
+        vm.startPrank(owner);
+        
+        // Set up batch data
+        address[] memory operators = new address[](3);
+        address[] memory signingKeys = new address[](3);
+        uint256[] memory weights = new uint256[](3);
+        
+        operators[0] = operator1;
+        operators[1] = operator2;
+        operators[2] = operator3;
+        
+        signingKeys[0] = signingKey1;
+        signingKeys[1] = signingKey2;
+        signingKeys[2] = signingKey3;
+        
+        weights[0] = WEIGHT_1;
+        weights[1] = WEIGHT_2;
+        weights[2] = WEIGHT_3;
+        
+        // Batch set operator details
+        registry.batchSetOperatorDetails(operators, signingKeys, weights);
+        
+        // Verify all operators' weights are set correctly
+        assertEq(registry.getOperatorWeight(operator1), WEIGHT_1, "Operator1 weight should be set correctly");
+        assertEq(registry.getOperatorWeight(operator2), WEIGHT_2, "Operator2 weight should be set correctly");
+        assertEq(registry.getOperatorWeight(operator3), WEIGHT_3, "Operator3 weight should be set correctly");
+        
+        // Verify all signing keys are associated with their operators
+        assertEq(registry.getLatestOperatorSigningKey(operator1), signingKey1, "Signing key1 should be set correctly");
+        assertEq(registry.getLatestOperatorSigningKey(operator2), signingKey2, "Signing key2 should be set correctly");
+        assertEq(registry.getLatestOperatorSigningKey(operator3), signingKey3, "Signing key3 should be set correctly");
+        
+        // Verify all operators are associated with their signing keys
+        assertEq(registry.getLatestOperatorForSigningKey(signingKey1), operator1, "Operator1 should be associated with signing key1");
+        assertEq(registry.getLatestOperatorForSigningKey(signingKey2), operator2, "Operator2 should be associated with signing key2");
+        assertEq(registry.getLatestOperatorForSigningKey(signingKey3), operator3, "Operator3 should be associated with signing key3");
+        
+        vm.stopPrank();
+    }
+
+    // Test updating an existing operator's details
+    function test_updateExistingOperator() public {
+        vm.startPrank(owner);
+        
+        // Set initial operator details
+        registry.setOperatorDetails(operator1, signingKey1, WEIGHT_1);
+        
+        // Update operator with new signing key and weight
+        address newSigningKey = address(0x111);
+        uint256 newWeight = 150;
+        registry.setOperatorDetails(operator1, newSigningKey, newWeight);
+        
+        // Verify the operator weight is updated
+        assertEq(registry.getOperatorWeight(operator1), newWeight, "Operator weight should be updated");
+        
+        // Verify the new signing key is associated with the operator
+        assertEq(registry.getLatestOperatorSigningKey(operator1), newSigningKey, "New signing key should be set");
+        
+        // Verify the old signing key is no longer associated with the operator
+        assertEq(registry.getLatestOperatorForSigningKey(signingKey1), address(0), "Old signing key should not be associated");
+        
+        // Verify the operator is associated with the new signing key
+        assertEq(registry.getLatestOperatorForSigningKey(newSigningKey), operator1, "Operator should be associated with new signing key");
+        
+        vm.stopPrank();
+    }
+
+    // Test batch input validation for mismatched array lengths
+    function test_batchSetOperatorDetails_mismatchedArrays() public {
+        vm.startPrank(owner);
+        
+        // Set up batch data with mismatched array lengths
+        address[] memory operators = new address[](3);
+        address[] memory signingKeys = new address[](2); // One less than operators
+        uint256[] memory weights = new uint256[](3);
+        
+        operators[0] = operator1;
+        operators[1] = operator2;
+        operators[2] = operator3;
+        
+        signingKeys[0] = signingKey1;
+        signingKeys[1] = signingKey2;
+        
+        weights[0] = WEIGHT_1;
+        weights[1] = WEIGHT_2;
+        weights[2] = WEIGHT_3;
+        
+        // Expect revert due to mismatched array lengths
+        vm.expectRevert(MirrorStakeRegistry.InvalidArrayLengths.selector);
+        registry.batchSetOperatorDetails(operators, signingKeys, weights);
+        
+        // Try another mismatch
+        signingKeys = new address[](3); // Now correct
+        weights = new uint256[](2); // Now this is wrong
+        
+        signingKeys[0] = signingKey1;
+        signingKeys[1] = signingKey2;
+        signingKeys[2] = signingKey3;
+        
+        weights[0] = WEIGHT_1;
+        weights[1] = WEIGHT_2;
+        
+        // Expect revert due to mismatched array lengths
+        vm.expectRevert(MirrorStakeRegistry.InvalidArrayLengths.selector);
+        registry.batchSetOperatorDetails(operators, signingKeys, weights);
+        
+        vm.stopPrank();
+    }
+
+    // Test getting operator weight at block
+    function test_getOperatorWeightAtBlock() public {
+        vm.startPrank(owner);
+        
+        // Set operator details
+        registry.setOperatorDetails(operator1, signingKey1, WEIGHT_1);
+        
+        // We need to roll to the next block to make the checkpoint available
+        vm.roll(block.number + 1);
+        
+        // Now we can get the weight at the previous block
+        uint32 previousBlock = uint32(block.number - 1);
+        
+        // Verify the operator weight at the previous block
+        assertEq(registry.getOperatorWeightAtBlock(operator1, previousBlock), WEIGHT_1, "Operator weight at block should be correct");
+        
+        vm.stopPrank();
+    }
+
+    // Test getting total weight
+    function test_getTotalWeight() public {
+        vm.startPrank(owner);
+        
+        // Set up batch data
+        address[] memory operators = new address[](3);
+        address[] memory signingKeys = new address[](3);
+        uint256[] memory weights = new uint256[](3);
+        
+        operators[0] = operator1;
+        operators[1] = operator2;
+        operators[2] = operator3;
+        
+        signingKeys[0] = signingKey1;
+        signingKeys[1] = signingKey2;
+        signingKeys[2] = signingKey3;
+        
+        weights[0] = WEIGHT_1;
+        weights[1] = WEIGHT_2;
+        weights[2] = WEIGHT_3;
+        
+        // Batch set operator details
+        registry.batchSetOperatorDetails(operators, signingKeys, weights);
+        
+        // Calculate expected total weight
+        uint256 expectedTotalWeight = WEIGHT_1 + WEIGHT_2 + WEIGHT_3;
+        
+        // Verify the total weight
+        assertEq(registry.getLastCheckpointTotalWeight(), expectedTotalWeight, "Total weight should be correct");
+        
+        // We need to roll to the next block to make the checkpoint available
+        vm.roll(block.number + 1);
+        
+        // Now we can get the weight at the previous block
+        uint32 previousBlock = uint32(block.number - 1);
+        
+        // Verify the total weight at the previous block
+        assertEq(registry.getLastCheckpointTotalWeightAtBlock(previousBlock), expectedTotalWeight, "Total weight at block should be correct");
+        
+        vm.stopPrank();
+    }
+
+    // Test isValidSignature functionality
+    function test_isValidSignature() public {
+        vm.startPrank(owner);
+        
+        // Set up operators with weights
+        address[] memory operators = new address[](3);
+        address[] memory signingKeys = new address[](3);
+        uint256[] memory weights = new uint256[](3);
+        
+        operators[0] = operator1;
+        operators[1] = operator2;
+        operators[2] = operator3;
+        
+        signingKeys[0] = signingKey1;
+        signingKeys[1] = signingKey2;
+        signingKeys[2] = signingKey3;
+        
+        weights[0] = WEIGHT_1;
+        weights[1] = WEIGHT_2;
+        weights[2] = WEIGHT_3;
+        
+        // Batch set operator details
+        registry.batchSetOperatorDetails(operators, signingKeys, weights);
+        
+        // Create a message to sign
+        bytes32 digest = keccak256("test message");
+        
+        // Roll to the next block to make the checkpoint available
+        vm.roll(block.number + 1);
+        
+        // Create signature data - ECDSAStakeRegistry.isValidSignature expects (address[] signers, bytes[] signatures, uint32 referenceBlock)
+        // The signers should be the signing keys, not the operators
+        address[] memory signers = new address[](3); // Include all three signing keys to meet the threshold
+        bytes[] memory signatures = new bytes[](3);
+        uint32 referenceBlock = uint32(block.number - 1); // Use the previous block as reference
+        
+        // Use all signing keys to meet the threshold weight
+        signers[0] = signingKey1;
+        signers[1] = signingKey2;
+        signers[2] = signingKey3;
+        
+        // Mock signatures (in a real scenario these would be valid signatures)
+        signatures[0] = abi.encodePacked(bytes32(0), bytes32(0), uint8(27));
+        signatures[1] = abi.encodePacked(bytes32(0), bytes32(0), uint8(28));
+        signatures[2] = abi.encodePacked(bytes32(0), bytes32(0), uint8(29));
+        
+        // Encode the signature data as expected by isValidSignature
+        bytes memory signatureData = abi.encode(signers, signatures, referenceBlock);
+        
+        // Mock the signature verification for all signing keys
+        vm.mockCall(
+            signingKey1,
+            abi.encodeWithSelector(IERC1271Upgradeable.isValidSignature.selector, digest, signatures[0]),
+            abi.encode(IERC1271Upgradeable.isValidSignature.selector)
+        );
+        
+        vm.mockCall(
+            signingKey2,
+            abi.encodeWithSelector(IERC1271Upgradeable.isValidSignature.selector, digest, signatures[1]),
+            abi.encode(IERC1271Upgradeable.isValidSignature.selector)
+        );
+        
+        vm.mockCall(
+            signingKey3,
+            abi.encodeWithSelector(IERC1271Upgradeable.isValidSignature.selector, digest, signatures[2]),
+            abi.encode(IERC1271Upgradeable.isValidSignature.selector)
+        );
+        
+        // Call isValidSignature
+        bytes4 result = registry.isValidSignature(digest, signatureData);
+        
+        // Verify the result
+        assertEq(result, IERC1271Upgradeable.isValidSignature.selector, "isValidSignature should return the correct selector");
+        
+        vm.stopPrank();
+    }
+}

--- a/contracts/eigenlayer/test/WavsMirrorDeploymentLib.t.sol
+++ b/contracts/eigenlayer/test/WavsMirrorDeploymentLib.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
+import {console} from "forge-std/console.sol";
 import "forge-std/Test.sol";
 import {WavsMirrorDeploymentLib} from "../script/utils/WavsMirrorDeploymentLib.sol";
 import {UpgradeableProxyLib} from "../script/utils/UpgradeableProxyLib.sol";
@@ -11,6 +12,13 @@ import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.s
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {IECDSAStakeRegistryTypes} from "@eigenlayer-middleware/src/interfaces/IECDSAStakeRegistry.sol";
+import {IWavsServiceHandler} from "../../interfaces/IWavsServiceHandler.sol";
+import {IWavsServiceManager} from "../../interfaces/IWavsServiceManager.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {ECDSAUpgradeable} from
+    "@openzeppelin-upgrades/contracts/utils/cryptography/ECDSAUpgradeable.sol";
+
+uint256 constant OPERATOR_WEIGHT = 10000;
 
 contract WavsMirrorDeploymentLibTest is Test {
     using UpgradeableProxyLib for address;
@@ -18,6 +26,16 @@ contract WavsMirrorDeploymentLibTest is Test {
     address private deployer;
     address private proxyAdmin;
     WavsMirrorDeploymentLib.DeploymentData private deployment;
+    
+    // basic operator data
+    address[] private operators;
+    address[] private signingKeys;
+    uint256[] private weights;
+    uint256[] private privateKeys;
+    
+    // References to deployed contracts
+    MirrorStakeRegistry private stakeRegistry;
+    WavsServiceManager private serviceManager;
 
     function setUp() public {
         // Set up deployer address
@@ -29,8 +47,35 @@ contract WavsMirrorDeploymentLibTest is Test {
         
         // Deploy contracts
         deployment = WavsMirrorDeploymentLib.deployContracts(proxyAdmin);
-        
         vm.stopPrank();
+        
+        // Create references to deployed contracts
+        stakeRegistry = MirrorStakeRegistry(deployment.stakeRegistry);
+        serviceManager = WavsServiceManager(deployment.WavsServiceManager);
+        
+        // Create test info for 5 operators        
+        privateKeys = new uint256[](5);
+        operators = new address[](5);
+        signingKeys = new address[](5);
+        weights = new uint256[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            privateKeys[i] = i+1;
+            operators[i] = vm.addr(privateKeys[i]); // Operators same as signing keys for now
+            signingKeys[i] = vm.addr(privateKeys[i]); // Signing keys derived from private keys
+            weights[i] = OPERATOR_WEIGHT; // Same weight for all operators
+        }
+
+        // Find out the actual owner of the contracts
+        address actualOwner = serviceManager.owner();
+        
+        // Set up test operator weights as the actual owner
+        vm.startPrank(actualOwner);
+        stakeRegistry.batchSetOperatorDetails(operators, signingKeys, weights);
+        vm.stopPrank();
+
+        // Roll to block 10 to make sure we have plenty of blocks for reference blocks
+        // This ensures we're at a high enough block number for the referenceBlockOffset in createSignatureData
+        vm.roll(10);
     }
     
     function test_initial_state() public view {
@@ -59,16 +104,305 @@ contract WavsMirrorDeploymentLibTest is Test {
         
         // Verify contract relationships
         MirrorStakeRegistry registry = MirrorStakeRegistry(deployment.stakeRegistry);
-        // WavsServiceManager serviceManager = WavsServiceManager(deployment.WavsServiceManager);
         
         assertEq(address(registry.serviceManager()), deployment.WavsServiceManager, "StakeRegistry should reference ServiceManager");
-        // TODO: owner is not deployer or proxyAdmin, how to fix?
-        // assertEq(registry.owner(), proxyAdmin, "StakeRegistry owner should be proxyAdmin");
-        // assertEq(serviceManager.owner(), proxyAdmin, "WavsServiceManager owner should be proxyAdmin");
         
         // Verify that the mock strategy is included in the quorum
         IECDSAStakeRegistryTypes.Quorum memory quorum = registry.quorum();
         assertEq(quorum.strategies.length, 1, "Quorum should have one strategy");
         assertEq(address(quorum.strategies[0].strategy), address(1), "Quorum strategy should be our mock strategy");
     }
+    
+    function test_validateQuorumSigned_success() public {
+        // Create the envelope
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(1)),
+            ordering: bytes12(0),
+            payload: "one"
+        });
+        
+        // Create signature data with first 4 operators (4/5 >= 2/3 == success)
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 4, 5);
+        
+        // Call validate
+        serviceManager.validate(
+            envelope,
+            signatureData
+        );
+    }
+    
+    function test_validateQuorumSigned_insufficient() public {
+        // Create the envelope
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(2)),
+            ordering: bytes12(0),
+            payload: "two"
+        });
+        
+        // Create signature data with first 3 operators (3/5 < 2/3 == failure)
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 3, 5);
+        
+        // Call validate fails
+        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InsufficientQuorum.selector, 30000, 33333, 50000));
+        serviceManager.validate(
+            envelope,
+            signatureData
+        );
+    }
+    
+    function test_validateQuorumSigned_exact() public {
+        // Change quorum to 3 of 5
+        address actualOwner = serviceManager.owner();
+        vm.startPrank(actualOwner);
+        serviceManager.setQuorumThreshold(3, 5);
+        vm.stopPrank();
+
+        // Create the envelope
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(3)),
+            ordering: bytes12(0),
+            payload: "three"
+        });
+        
+        // Create signature data with first 4 operators (3/5 >= 3/5 == success)
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 3, 5);
+        
+        // Call validate
+        serviceManager.validate(
+            envelope,
+            signatureData
+        );
+    }
+    
+    function test_validateQuorumSigned_explicitSigningKeys() public {
+        // Get the actual owner of the contracts
+        address actualOwner = serviceManager.owner();
+        
+        // Set a new private key and signing key
+        privateKeys[0] = 0x13579;
+        signingKeys[0] = vm.addr(privateKeys[0]);
+        
+        // Update operator to use new signing key
+        // Change quorum to 1 of 5, so we just test one signer
+        vm.startPrank(actualOwner);
+        serviceManager.setQuorumThreshold(1, 5);
+        stakeRegistry.setOperatorDetails(operators[0], signingKeys[0], OPERATOR_WEIGHT);
+        vm.roll(block.number + 4);
+        vm.stopPrank();
+        
+        // Add a query to check the signing key registered properly
+        address registeredSigningKey = stakeRegistry.getLatestOperatorSigningKey(operators[0]);
+        assertEq(registeredSigningKey, signingKeys[0], "Signing key not registered correctly");
+        address registeredOperator = stakeRegistry.getLatestOperatorForSigningKey(signingKeys[0]);
+        assertEq(registeredOperator, operators[0], "Operator not registered correctly");
+
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(4)),
+            ordering: bytes12(0),
+            payload: "four"
+        });
+
+        // One operator will match threshold. Ensure lookup by signing key works well.        
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 1, 0);
+
+        // Call validate
+        serviceManager.validate(
+            envelope,
+            signatureData
+        );
+    }
+    
+    function test_setQuorumThreshold() public {
+        // Change quorum to 3 of 5
+        address actualOwner = serviceManager.owner();
+        vm.startPrank(actualOwner);
+        serviceManager.setQuorumThreshold(51, 100);
+        vm.stopPrank();
+
+        assertEq(serviceManager.quorumNumerator(), 51, "Quorum numerator should be updated");
+        assertEq(serviceManager.quorumDenominator(), 100, "Quorum denominator should be updated");
+
+
+        // Create the envelope
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(5)),
+            ordering: bytes12(0),
+            payload: "five"
+        });
+        
+        // Create signature data with first 3 operators (3/5 >= 51% == success)
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 3, 1);        
+        // Call validate passes
+        serviceManager.validate(
+            envelope,
+            signatureData
+        );
+
+        // Create signature data with first 2 operators (2/5 < 51% == failure)
+        signatureData = createSignatureData(envelope, 2, 1);
+        // Call validate fails
+        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InsufficientQuorum.selector, 20000, 25500, 50000));
+        serviceManager.validate(
+            envelope,
+            signatureData
+        );
+    }
+
+    function test_setQuorumThreshold_only_owner() public {
+        // Non-owner should not be able to set quorum threshold
+        vm.prank(address(0x999));
+        vm.expectRevert("Ownable: caller is not the owner");
+        serviceManager.setQuorumThreshold(1, 2);
+    }
+    
+    function test_setQuorumThreshold_invalid_params() public {
+        // Get the actual owner of the contracts
+        address actualOwner = serviceManager.owner();
+        
+        // Need to call as the owner
+        vm.startPrank(actualOwner);
+        
+        // 0/5 should fail
+        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InvalidQuorumParameters.selector));
+        serviceManager.setQuorumThreshold(0, 5);
+        
+        // 0/0 should fail
+        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InvalidQuorumParameters.selector));
+        serviceManager.setQuorumThreshold(0, 0);
+        
+        // 6/5 should fail
+        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InvalidQuorumParameters.selector));
+        serviceManager.setQuorumThreshold(6, 5);
+        
+        vm.stopPrank();
+    }
+    
+    function test_validate_invalid_signature_length() public {
+        // Empty operators array
+        address[] memory emptySigners = new address[](0);
+        bytes[] memory emptySignatures = new bytes[](0);
+        
+        vm.expectRevert(abi.encodeWithSelector(IWavsServiceManager.InvalidSignatureLength.selector));
+        serviceManager.validate(
+            IWavsServiceHandler.Envelope({
+                eventId: bytes20(0),
+                ordering: bytes12(0),
+                payload: ""
+            }),
+            IWavsServiceHandler.SignatureData({
+                signers: emptySigners,
+                signatures: emptySignatures,
+                referenceBlock: 1
+            })
+        );
+    }
+    
+    // Helper function to create signature data with a specific number of operators and real signatures
+    function createSignatureData(
+        IWavsServiceHandler.Envelope memory envelope,
+        uint256 numOperators,
+        uint32 referenceBlockOffset
+    ) internal returns (IWavsServiceHandler.SignatureData memory) {
+        // Create digest using the same logic as WavsServiceManager
+        bytes32 message = keccak256(abi.encode(envelope));
+        bytes32 digest = ECDSAUpgradeable.toEthSignedMessageHash(message);
+        
+        // Create signature data with the desired number of signers
+        address[] memory signers = new address[](numOperators);
+        bytes[] memory signatures = new bytes[](numOperators);
+        
+        for (uint256 i = 0; i < numOperators; i++) {
+            // Generate signer address from private key
+            signers[i] = vm.addr(privateKeys[i]);
+            
+            // Generate signature using private key
+            signatures[i] = generateSignature(privateKeys[i], digest);
+        }
+
+        // console.log("Signers");
+        // for (uint i = 0; i < signers.length; i++) {
+        //    console.log(signers[i]);
+        // }
+
+        // Sort signers and signatures by signer address11
+        sortSignersAndSignatures(signers, signatures);
+        
+        // Verify signatures
+        verifySignatures(digest, signers, signatures);
+        
+        // Create signature data
+        // Note: referenceBlock must be a valid block that exists and is in the past
+        // Make sure we're at least at block 1 before subtracting offset
+        uint32 currentBlock = uint32(block.number);
+        require(currentBlock > referenceBlockOffset, "Block number too low for offset");
+        
+        return IWavsServiceHandler.SignatureData({
+            signers: signers,
+            signatures: signatures,
+            referenceBlock: currentBlock - 1 - referenceBlockOffset
+        });
+    }
+
+        /**
+     * @notice Helper function to sort signers and their corresponding signatures in ascending order by signer address
+     * @dev ECDSAStakeRegistry requires signers to be sorted in ascending order
+     * @param signers Array of signer addresses
+     * @param signatures Array of signatures that correspond to signers at the same index
+     */
+    function sortSignersAndSignatures(
+        address[] memory signers,
+        bytes[] memory signatures
+    ) internal pure {
+        // Simple bubble sort since we're working with small arrays
+        uint256 length = signers.length;
+        for (uint256 i = 0; i < length - 1; i++) {
+            for (uint256 j = 0; j < length - i - 1; j++) {
+                if (signers[j] > signers[j + 1]) {
+                    // Swap signers
+                    address tempAddr = signers[j];
+                    signers[j] = signers[j + 1];
+                    signers[j + 1] = tempAddr;
+                    
+                    // Swap corresponding signatures
+                    bytes memory tempSig = signatures[j];
+                    signatures[j] = signatures[j + 1];
+                    signatures[j + 1] = tempSig;
+                }
+            }
+        }
+    }
+    
+    /**
+     * @notice Helper function to generate an ECDSA signature using a private key
+     * @param privateKey The private key to sign with
+     * @param digest The message hash to sign
+     * @return The signature in bytes format ready for validation
+     */
+    function generateSignature(
+        uint256 privateKey,
+        bytes32 digest
+    ) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+    
+    /**
+     * @notice Helper function to verify that signatures can be recovered to the expected signers
+     * @param digest Message hash that was signed
+     * @param signers Array of signer addresses (should be sorted)
+     * @param signatures Array of signatures corresponding to signers
+     */
+    function verifySignatures(
+        bytes32 digest,
+        address[] memory signers,
+        bytes[] memory signatures
+    ) internal pure {
+        require(signers.length == signatures.length, "Arrays length mismatch");
+        
+        for (uint256 i = 0; i < signers.length; i++) {
+            address recovered = ECDSA.recover(digest, signatures[i]);
+            require(recovered == signers[i], "Signature recovery failed");
+        }
+    }
+
 }

--- a/contracts/eigenlayer/test/WavsMirrorDeploymentLib.t.sol
+++ b/contracts/eigenlayer/test/WavsMirrorDeploymentLib.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import {WavsMirrorDeploymentLib} from "../script/utils/WavsMirrorDeploymentLib.sol";
+import {UpgradeableProxyLib} from "../script/utils/UpgradeableProxyLib.sol";
+import {MirrorStakeRegistry} from "../src/MirrorStakeRegistry.sol";
+import {WavsServiceManager} from "../src/WavsServiceManager.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {IECDSAStakeRegistryTypes} from "@eigenlayer-middleware/src/interfaces/IECDSAStakeRegistry.sol";
+
+contract WavsMirrorDeploymentLibTest is Test {
+    using UpgradeableProxyLib for address;
+
+    address private deployer;
+    address private proxyAdmin;
+    WavsMirrorDeploymentLib.DeploymentData private deployment;
+
+    function setUp() public {
+        // Set up deployer address
+        deployer = address(0x123);
+        vm.startPrank(deployer);
+        
+        // Deploy proxy admin
+        proxyAdmin = UpgradeableProxyLib.deployProxyAdmin();
+        
+        // Deploy contracts
+        deployment = WavsMirrorDeploymentLib.deployContracts(proxyAdmin);
+        
+        vm.stopPrank();
+    }
+    
+    function test_initial_state() public view {
+        // Verify deployment addresses are set correctly
+        assertNotEq(deployment.stakeRegistry, address(0), "StakeRegistry address cannot be zero");
+        assertNotEq(deployment.WavsServiceManager, address(0), "WavsServiceManager address cannot be zero");
+        assertNotEq(proxyAdmin, address(0), "ProxyAdmin address cannot be zero");
+        
+        // Verify proxy admin relationships
+        address stakeRegistryProxyAdmin = address(
+            UpgradeableProxyLib.getProxyAdmin(deployment.stakeRegistry)
+        );
+        address serviceManagerProxyAdmin = address(
+            UpgradeableProxyLib.getProxyAdmin(deployment.WavsServiceManager)
+        );
+        
+        assertEq(stakeRegistryProxyAdmin, proxyAdmin, "StakeRegistry proxy admin should match");
+        assertEq(serviceManagerProxyAdmin, proxyAdmin, "WavsServiceManager proxy admin should match");
+        
+        // Check implementation addresses
+        address stakeRegistryImpl = deployment.stakeRegistry.getImplementation();
+        address serviceManagerImpl = deployment.WavsServiceManager.getImplementation();
+        
+        assertNotEq(stakeRegistryImpl, address(0), "StakeRegistry implementation cannot be zero");
+        assertNotEq(serviceManagerImpl, address(0), "WavsServiceManager implementation cannot be zero");
+        
+        // Verify contract relationships
+        MirrorStakeRegistry registry = MirrorStakeRegistry(deployment.stakeRegistry);
+        // WavsServiceManager serviceManager = WavsServiceManager(deployment.WavsServiceManager);
+        
+        assertEq(address(registry.serviceManager()), deployment.WavsServiceManager, "StakeRegistry should reference ServiceManager");
+        // TODO: owner is not deployer or proxyAdmin, how to fix?
+        // assertEq(registry.owner(), proxyAdmin, "StakeRegistry owner should be proxyAdmin");
+        // assertEq(serviceManager.owner(), proxyAdmin, "WavsServiceManager owner should be proxyAdmin");
+        
+        // Verify that the mock strategy is included in the quorum
+        IECDSAStakeRegistryTypes.Quorum memory quorum = registry.quorum();
+        assertEq(quorum.strategies.length, 1, "Quorum should have one strategy");
+        assertEq(address(quorum.strategies[0].strategy), address(1), "Quorum strategy should be our mock strategy");
+    }
+}


### PR DESCRIPTION
Fixes issue #112 
Fixes issue #113 

I want to use deployment script for test setUp, so I make one PR for both issues.

Implement MirrorStakeRegistry as subclass of  ECDSAStakeRegistry. Remove normal update methods and add new update method to control validation data by owner. I do not cut and paste the ECDSAStakeRegistry so less code to audit.
