### PR TITLE
157 Add BLS Deploy Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cp docker/env.example docker/.env
 Start anvil in one terminal:
 
 ```bash
-export RPC_URL=https://ethereum-holesky-rpc.publicnode.com
+RPC_URL=https://ethereum-holesky-rpc.publicnode.com
 anvil --fork-url $RPC_URL --host 0.0.0.0 --port 8545
 ```
 
@@ -57,9 +57,10 @@ cd docker/
 Deploy:
 
 ```bash
-export METADATA_URI=https://wavs.xyz/metadata.json
-export FUNDED_KEY=
-export LST_STRATEGY_ADDRESS=0x7D704507b76571a51d9caE8AdDAbBFd0ba0e63d3
+# ecdsa contracts deployment
+FUNDED_KEY=
+METADATA_URI=https://wavs.xyz/metadata.json
+LST_STRATEGY_ADDRESS=0x7D704507b76571a51d9caE8AdDAbBFd0ba0e63d3
 
 docker run --rm --network host -v ./.nodes:/root/.nodes \
    -e DEPLOY_ENV=${DEPLOY_ENV} \
@@ -69,12 +70,24 @@ docker run --rm --network host -v ./.nodes:/root/.nodes \
    -e METADATA_URI=${METADATA_URI} \
    -e LST_STRATEGY_ADDRESS=${LST_STRATEGY_ADDRESS} \
    wavs-middleware deploy
+
+# bls contracts deployment
+FUNDED_KEY=
+METADATA_URI=https://wavs.xyz/metadata.json
+
+docker run --rm --network host -v ./.nodes:/root/.nodes \
+   -e DEPLOY_ENV=${DEPLOY_ENV} \
+   -e LOCAL_ETHEREUM_RPC_URL=${LOCAL_ETHEREUM_RPC_URL} \
+   -e TESTNET_RPC_URL=${TESTNET_RPC_URL} \
+   -e FUNDED_KEY=${FUNDED_KEY} \
+   -e METADATA_URI=${METADATA_URI} \
+   wavs-middleware -s bls deploy
 ```
 
 Set Service URI:
 
 ```bash
-export SERVICE_URI="https://ipfs.url/for-custom-service.json"
+SERVICE_URI="https://ipfs.url/for-custom-service.json"
 
 docker run --rm --network host -v ./.nodes:/root/.nodes \
    -e DEPLOY_ENV=${DEPLOY_ENV} \
@@ -224,8 +237,8 @@ List Mirror Operators:
 
 ```bash
 MIRROR_CHAIN_ID=$(cast chain-id --rpc-url http://localhost:8546)
-export SOURCE_SERVICE_MANAGER_ADDRESS=$(jq -r '.addresses.WavsServiceManager' ".nodes/avs_deploy.json")
-export MIRROR_SERVICE_MANAGER_ADDRESS=$(jq -r '.addresses.WavsServiceManager' ".nodes/mirror-$MIRROR_CHAIN_ID.json")
+SOURCE_SERVICE_MANAGER_ADDRESS=$(jq -r '.addresses.WavsServiceManager' ".nodes/avs_deploy.json")
+MIRROR_SERVICE_MANAGER_ADDRESS=$(jq -r '.addresses.WavsServiceManager' ".nodes/mirror-$MIRROR_CHAIN_ID.json")
 
 # View stake registry status, including registered operators and their weights
 docker run --rm --network host \
@@ -278,7 +291,7 @@ anvil --host 0.0.0.0 --port 8546
 
 ```bash
 # Set the path to your local config file
-export LOCAL_CONFIG_PATH=$(pwd)/mock-config.json
+LOCAL_CONFIG_PATH=$(pwd)/mock-config.json
 
 # Generate a new private key for the staker (needs ETH for transactions)
 MOCK_DEPLOYER_KEY=$(cast wallet new --json | jq -r '.[0].private_key')

--- a/contracts/deployments/eigenlayer-core/17000.json
+++ b/contracts/deployments/eigenlayer-core/17000.json
@@ -15,7 +15,9 @@
     "strategyBeacon": "0xd3c6C6BA4E40dB9288c6a2077e5635344F8aFA4F",
     "allocationManager": "0x78469728304326CBc65f8f95FA756B0B73164462",
     "rewardsCoordinator": "0xAcc1fb458a1317E886dB376Fc8141540537E68fE",
-    "rewardsCoordinatorImpl": "0xA3c31d2FBAD3d924baA64f8789E03E9FA7d70d69"
+    "rewardsCoordinatorImpl": "0xA3c31d2FBAD3d924baA64f8789E03E9FA7d70d69",
+    "permissionController": "0x598cb226B591155F767dA17AfE7A2241a68C5C10",
+    "permissionControllerImpl": "0x7Ab0EBD25d5fFE7527600CA5b2858c1A3FABa2B9"
   },
   "metaDataURI": "https://raw.githubusercontent.com/ethgas-developer/ethgas-developer.github.io/main/vision-avs-2.json"
 }

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -8,7 +8,7 @@ fs_permissions = [{ access = "read-write", path = "./" }, { access = "read", pat
 solc = "0.8.27"
 via-ir = true
 optimizer = true
-optimizer_runs = 1000000
+optimizer_runs = 100
  # Higher number optimizes for frequent contract calls, lower number optimizes for deployment cost
 
 

--- a/contracts/script/eigenlayer/bls/WavsMiddlewareDeployer.s.sol
+++ b/contracts/script/eigenlayer/bls/WavsMiddlewareDeployer.s.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import {Script} from "forge-std/Script.sol";
+
+import {RegistryCoordinator} from "@eigenlayer-middleware/src/RegistryCoordinator.sol";
+import {StakeRegistry} from "@eigenlayer-middleware/src/StakeRegistry.sol";
+import {BLSApkRegistry} from "@eigenlayer-middleware/src/BLSApkRegistry.sol";
+import {IndexRegistry} from "@eigenlayer-middleware/src/IndexRegistry.sol";
+import {SocketRegistry} from "@eigenlayer-middleware/src/SocketRegistry.sol";
+import {PauserRegistry} from "@eigenlayer/contracts/permissions/PauserRegistry.sol";
+import {IStakeRegistryTypes} from "@eigenlayer-middleware/src/interfaces/IStakeRegistry.sol";
+
+import {WavsMiddlewareDeploymentLib} from "./utils/WavsMiddlewareDeploymentLib.sol";
+import {WavsServiceManager} from "src/eigenlayer/bls/WavsServiceManager.sol";
+import {ReadCoreLib} from "./utils/ReadCoreLib.sol";
+import {UpgradeableProxyLib} from "./utils/UpgradeableProxyLib.sol";
+
+contract WavsMiddlewareDeployer is Script {
+    using UpgradeableProxyLib for address;
+
+    // Environment variables for configureContracts
+    string public constant ENV_METADATA_URI = "METADATA_URI";
+
+    // Deployment configuration
+    string private _metadataUri;
+
+    address public proxyAdmin;
+    ReadCoreLib.DeploymentData public coreDeployment;
+    WavsMiddlewareDeploymentLib.DeploymentData public wavsMiddlewareDeployment;
+    IStakeRegistryTypes.StrategyParams[] public strategyParams;
+
+    error WavsMiddlewareDeployer__WavsServiceManagerMismatch();
+    error WavsMiddlewareDeployer__StakeRegistryMismatch();
+    error WavsMiddlewareDeployer__RegistryCoordinatorMismatch();
+    error WavsMiddlewareDeployer__BLSApkRegistryMismatch();
+    error WavsMiddlewareDeployer__IndexRegistryMismatch();
+    error WavsMiddlewareDeployer__SocketRegistryMismatch();
+    error WavsMiddlewareDeployer__PauserRegistryMismatch();
+
+    function setUp() public virtual {
+        coreDeployment =
+            ReadCoreLib.readDeploymentJson("deployments/eigenlayer-core/", block.chainid);
+
+        _metadataUri = vm.envString(ENV_METADATA_URI);
+
+        string memory fileName =
+            string.concat("deployments/strategies/", vm.toString(block.chainid), ".json");
+        strategyParams = WavsMiddlewareDeploymentLib.readStrategyParamsConfig(fileName);
+    }
+
+    function run() external {
+        vm.startBroadcast();
+        proxyAdmin = UpgradeableProxyLib.deployProxyAdmin();
+
+        // first deploy (from eigenlayer)
+        wavsMiddlewareDeployment =
+            WavsMiddlewareDeploymentLib.deployContracts(proxyAdmin, coreDeployment);
+
+        // WAVS configuration
+        uint96 minimumWeight = 100;
+        WavsMiddlewareDeploymentLib.configureContracts(
+            wavsMiddlewareDeployment,
+            strategyParams,
+            _metadataUri,
+            coreDeployment.allocationManager,
+            coreDeployment.permissionController,
+            minimumWeight
+        );
+
+        vm.stopBroadcast();
+
+        _verifyDeployment();
+        WavsMiddlewareDeploymentLib.writeDeploymentJson(
+            "deployments/wavs-middleware/", block.chainid, wavsMiddlewareDeployment
+        );
+    }
+
+    function _verifyDeployment() internal view {
+        WavsServiceManager wavsServiceManager =
+            WavsServiceManager(wavsMiddlewareDeployment.wavsServiceManager);
+        StakeRegistry stakeRegistry = StakeRegistry(wavsMiddlewareDeployment.stakeRegistry);
+        RegistryCoordinator registryCoordinator =
+            RegistryCoordinator(wavsMiddlewareDeployment.registryCoordinator);
+        BLSApkRegistry blsApkRegistry = BLSApkRegistry(wavsMiddlewareDeployment.blsApkRegistry);
+        IndexRegistry indexRegistry = IndexRegistry(wavsMiddlewareDeployment.indexRegistry);
+        SocketRegistry socketRegistry = SocketRegistry(wavsMiddlewareDeployment.socketRegistry);
+        PauserRegistry pauserRegistry = PauserRegistry(wavsMiddlewareDeployment.pauserRegistry);
+
+        if (wavsServiceManager.avsDirectory() != coreDeployment.avsDirectory) {
+            revert WavsMiddlewareDeployer__WavsServiceManagerMismatch();
+        }
+        if (
+            address(stakeRegistry.delegation()) != coreDeployment.delegationManager
+                || address(stakeRegistry.avsDirectory()) != coreDeployment.avsDirectory
+                || address(stakeRegistry.allocationManager()) != coreDeployment.allocationManager
+                || address(stakeRegistry.registryCoordinator())
+                    != wavsMiddlewareDeployment.registryCoordinator
+        ) {
+            revert WavsMiddlewareDeployer__StakeRegistryMismatch();
+        }
+        if (
+            address(registryCoordinator.serviceManager())
+                != wavsMiddlewareDeployment.wavsServiceManager
+                || address(registryCoordinator.stakeRegistry())
+                    != wavsMiddlewareDeployment.stakeRegistry
+                || address(registryCoordinator.blsApkRegistry())
+                    != wavsMiddlewareDeployment.blsApkRegistry
+                || address(registryCoordinator.indexRegistry())
+                    != wavsMiddlewareDeployment.indexRegistry
+                || address(registryCoordinator.socketRegistry())
+                    != wavsMiddlewareDeployment.socketRegistry
+                || address(registryCoordinator.allocationManager()) != coreDeployment.allocationManager
+                || address(registryCoordinator.pauserRegistry())
+                    != wavsMiddlewareDeployment.pauserRegistry
+        ) {
+            revert WavsMiddlewareDeployer__RegistryCoordinatorMismatch();
+        }
+        if (blsApkRegistry.registryCoordinator() != wavsMiddlewareDeployment.registryCoordinator) {
+            revert WavsMiddlewareDeployer__BLSApkRegistryMismatch();
+        }
+        if (indexRegistry.registryCoordinator() != wavsMiddlewareDeployment.registryCoordinator) {
+            revert WavsMiddlewareDeployer__IndexRegistryMismatch();
+        }
+        if (
+            socketRegistry.slashingRegistryCoordinator()
+                != wavsMiddlewareDeployment.registryCoordinator
+        ) {
+            revert WavsMiddlewareDeployer__SocketRegistryMismatch();
+        }
+        if (
+            wavsMiddlewareDeployment.pauserRegistry == address(0)
+                || pauserRegistry.unpauser() != msg.sender
+                || pauserRegistry.isPauser(msg.sender) == false
+        ) {
+            revert WavsMiddlewareDeployer__PauserRegistryMismatch();
+        }
+    }
+}

--- a/contracts/script/eigenlayer/bls/utils/ReadCoreLib.sol
+++ b/contracts/script/eigenlayer/bls/utils/ReadCoreLib.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import {Vm} from "forge-std/Vm.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+library ReadCoreLib {
+    using stdJson for *;
+    using Strings for *;
+
+    struct DeploymentData {
+        address delegationManager;
+        address avsDirectory;
+        address strategyManager;
+        address eigenPodManager;
+        address strategyFactory;
+        address rewardsCoordinator;
+        address allocationManager;
+        address permissionController;
+    }
+
+    Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    error ReadCoreLib__DelegationManagerAddressCannotBeZero();
+    error ReadCoreLib__AVSDirectoryAddressCannotBeZero();
+    error ReadCoreLib__StrategyManagerAddressCannotBeZero();
+    error ReadCoreLib__EigenPodManagerAddressCannotBeZero();
+    error ReadCoreLib__StrategyFactoryAddressCannotBeZero();
+    error ReadCoreLib__RewardsCoordinatorAddressCannotBeZero();
+    error ReadCoreLib__AllocationManagerAddressCannotBeZero();
+    error ReadCoreLib__PermissionControllerAddressCannotBeZero();
+
+    function readDeploymentJson(
+        string memory deploymentPath,
+        uint256 chainId
+    ) internal view returns (DeploymentData memory) {
+        string memory json =
+            VM.readFile(string.concat(deploymentPath, uint256(chainId).toString(), ".json"));
+
+        DeploymentData memory data;
+        data = readAddressSet(json, data);
+        validateDeployment(data);
+        return data;
+    }
+
+    function readAddressSet(
+        string memory json,
+        DeploymentData memory data
+    ) private pure returns (DeploymentData memory) {
+        data.strategyFactory = json.readAddress(".addresses.strategyFactory");
+        data.strategyManager = json.readAddress(".addresses.strategyManager");
+        data.eigenPodManager = json.readAddress(".addresses.eigenPodManager");
+        data.delegationManager = json.readAddress(".addresses.delegation");
+        data.avsDirectory = json.readAddress(".addresses.avsDirectory");
+        data.rewardsCoordinator = json.readAddress(".addresses.rewardsCoordinator");
+        data.allocationManager = json.readAddress(".addresses.allocationManager");
+        data.permissionController = json.readAddress(".addresses.permissionController");
+
+        return data;
+    }
+
+    function validateDeployment(
+        DeploymentData memory data
+    ) private pure {
+        if (data.delegationManager == address(0)) {
+            revert ReadCoreLib__DelegationManagerAddressCannotBeZero();
+        }
+        if (data.avsDirectory == address(0)) {
+            revert ReadCoreLib__AVSDirectoryAddressCannotBeZero();
+        }
+        if (data.strategyManager == address(0)) {
+            revert ReadCoreLib__StrategyManagerAddressCannotBeZero();
+        }
+        if (data.eigenPodManager == address(0)) {
+            revert ReadCoreLib__EigenPodManagerAddressCannotBeZero();
+        }
+        if (data.strategyFactory == address(0)) {
+            revert ReadCoreLib__StrategyFactoryAddressCannotBeZero();
+        }
+        if (data.rewardsCoordinator == address(0)) {
+            revert ReadCoreLib__RewardsCoordinatorAddressCannotBeZero();
+        }
+        if (data.allocationManager == address(0)) {
+            revert ReadCoreLib__AllocationManagerAddressCannotBeZero();
+        }
+        if (data.permissionController == address(0)) {
+            revert ReadCoreLib__PermissionControllerAddressCannotBeZero();
+        }
+    }
+}

--- a/contracts/script/eigenlayer/bls/utils/UpgradeableProxyLib.sol
+++ b/contracts/script/eigenlayer/bls/utils/UpgradeableProxyLib.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import {Vm} from "forge-std/Vm.sol";
+import {EmptyContract} from "@eigenlayer/test/mocks/EmptyContract.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {
+    TransparentUpgradeableProxy,
+    ITransparentUpgradeableProxy
+} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+library UpgradeableProxyLib {
+    bytes32 internal constant IMPLEMENTATION_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+    bytes32 internal constant ADMIN_SLOT =
+        0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+    Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function deployProxyAdmin() internal returns (address) {
+        return address(new ProxyAdmin());
+    }
+
+    function setUpEmptyProxy(
+        address admin
+    ) internal returns (address) {
+        address emptyContract = address(new EmptyContract());
+        return address(new TransparentUpgradeableProxy(emptyContract, admin, ""));
+    }
+
+    function upgrade(address proxy, address impl) internal {
+        ProxyAdmin admin = getProxyAdmin(proxy);
+        admin.upgrade(ITransparentUpgradeableProxy(payable(proxy)), impl);
+    }
+
+    function upgradeAndCall(address proxy, address impl, bytes memory initData) internal {
+        ProxyAdmin admin = getProxyAdmin(proxy);
+        admin.upgradeAndCall(ITransparentUpgradeableProxy(payable(proxy)), impl, initData);
+    }
+
+    function getImplementation(
+        address proxy
+    ) internal view returns (address) {
+        bytes32 value = VM.load(proxy, IMPLEMENTATION_SLOT);
+        return address(uint160(uint256(value)));
+    }
+
+    function getProxyAdmin(
+        address proxy
+    ) internal view returns (ProxyAdmin) {
+        bytes32 value = VM.load(proxy, ADMIN_SLOT);
+        return ProxyAdmin(address(uint160(uint256(value))));
+    }
+}

--- a/contracts/script/eigenlayer/bls/utils/WavsMiddlewareDeploymentLib.sol
+++ b/contracts/script/eigenlayer/bls/utils/WavsMiddlewareDeploymentLib.sol
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import {console2} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+import {StakeRegistry} from "@eigenlayer-middleware/src/StakeRegistry.sol";
+import {BLSApkRegistry} from "@eigenlayer-middleware/src/BLSApkRegistry.sol";
+import {IndexRegistry} from "@eigenlayer-middleware/src/IndexRegistry.sol";
+import {SocketRegistry} from "@eigenlayer-middleware/src/SocketRegistry.sol";
+import {RegistryCoordinator} from "@eigenlayer-middleware/src/RegistryCoordinator.sol";
+import {SlashingRegistryCoordinator} from
+    "@eigenlayer-middleware/src/SlashingRegistryCoordinator.sol";
+
+import {
+    IStakeRegistry,
+    IStakeRegistryTypes
+} from "@eigenlayer-middleware/src/interfaces/IStakeRegistry.sol";
+import {IBLSApkRegistry} from "@eigenlayer-middleware/src/interfaces/IBLSApkRegistry.sol";
+import {IIndexRegistry} from "@eigenlayer-middleware/src/interfaces/IIndexRegistry.sol";
+import {ISocketRegistry} from "@eigenlayer-middleware/src/interfaces/ISocketRegistry.sol";
+import {IServiceManager} from "@eigenlayer-middleware/src/interfaces/IServiceManager.sol";
+import {IRegistryCoordinatorTypes} from
+    "@eigenlayer-middleware/src/interfaces/IRegistryCoordinator.sol";
+import {
+    ISlashingRegistryCoordinator,
+    ISlashingRegistryCoordinatorTypes
+} from "@eigenlayer-middleware/src/interfaces/ISlashingRegistryCoordinator.sol";
+
+import {PauserRegistry} from "@eigenlayer/contracts/permissions/PauserRegistry.sol";
+import {IPauserRegistry} from "@eigenlayer/contracts/interfaces/IPauserRegistry.sol";
+import {IPermissionController} from "@eigenlayer/contracts/interfaces/IPermissionController.sol";
+import {IAVSRegistrar} from "@eigenlayer/contracts/interfaces/IAVSRegistrar.sol";
+import {IAllocationManager} from "@eigenlayer/contracts/interfaces/IAllocationManager.sol";
+import {IAVSDirectory} from "@eigenlayer/contracts/interfaces/IAVSDirectory.sol";
+import {IDelegationManager} from "@eigenlayer/contracts/interfaces/IDelegationManager.sol";
+import {IStrategy} from "@eigenlayer/contracts/interfaces/IStrategy.sol";
+
+import {UpgradeableProxyLib} from "./UpgradeableProxyLib.sol";
+import {ReadCoreLib} from "./ReadCoreLib.sol";
+import {WavsServiceManager} from "src/eigenlayer/bls/WavsServiceManager.sol";
+
+library WavsMiddlewareDeploymentLib {
+    // using stdJson for *;
+    using Strings for *;
+    using UpgradeableProxyLib for address;
+
+    struct DeploymentData {
+        address wavsServiceManager;
+        address stakeRegistry;
+        address registryCoordinator;
+        address blsApkRegistry;
+        address indexRegistry;
+        address socketRegistry;
+        address pauserRegistry;
+    }
+
+    struct StrategyConfig {
+        address strategy;
+        uint96 multiplier;
+    }
+
+    Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    error WavsMiddlewareDeploymentLib__StrategiesFileNotFound();
+    error WavsMiddlewareDeploymentLib__DeploymentFileNotFound();
+    error WavsMiddlewareDeploymentLib__StrategiesAndMultipliersLengthMismatch();
+    error WavsMiddlewareDeploymentLib__TotalMultiplierNot10000();
+    error WavsMiddlewareDeploymentLib__AVSDirectoryMismatch();
+
+    function deployContracts(
+        address proxyAdmin,
+        ReadCoreLib.DeploymentData memory core
+    ) internal returns (DeploymentData memory) {
+        // First, deploy upgradeable proxy contracts that will point to the implementations.
+        address wavsServiceManager = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        address stakeRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        address registryCoordinator = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        address blsApkRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        address indexRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        address socketRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+
+        address[] memory pausers = new address[](1);
+        pausers[0] = msg.sender;
+        address pauserRegistry = address(new PauserRegistry(pausers, msg.sender));
+
+        address wavsServiceManagerImpl = address(
+            new WavsServiceManager(
+                core.avsDirectory,
+                core.rewardsCoordinator,
+                registryCoordinator,
+                stakeRegistry,
+                core.permissionController,
+                core.allocationManager
+            )
+        );
+        address stakeRegistryImpl = address(
+            new StakeRegistry(
+                ISlashingRegistryCoordinator(registryCoordinator),
+                IDelegationManager(core.delegationManager),
+                IAVSDirectory(core.avsDirectory),
+                IAllocationManager(core.allocationManager)
+            )
+        );
+        address registryCoordinatorImpl = address(
+            new RegistryCoordinator(
+                IRegistryCoordinatorTypes.RegistryCoordinatorParams({
+                    serviceManager: IServiceManager(wavsServiceManager),
+                    slashingParams: IRegistryCoordinatorTypes.SlashingRegistryParams({
+                        stakeRegistry: IStakeRegistry(stakeRegistry),
+                        blsApkRegistry: IBLSApkRegistry(blsApkRegistry),
+                        indexRegistry: IIndexRegistry(indexRegistry),
+                        socketRegistry: ISocketRegistry(socketRegistry),
+                        allocationManager: IAllocationManager(core.allocationManager),
+                        pauserRegistry: IPauserRegistry(pauserRegistry)
+                    })
+                })
+            )
+        );
+
+        address blsApkRegistryImpl =
+            address(new BLSApkRegistry(ISlashingRegistryCoordinator(registryCoordinator)));
+        address indexRegistryImpl =
+            address(new IndexRegistry(ISlashingRegistryCoordinator(registryCoordinator)));
+        address socketRegistryImpl =
+            address(new SocketRegistry(ISlashingRegistryCoordinator(registryCoordinator)));
+
+        UpgradeableProxyLib.upgradeAndCall(
+            wavsServiceManager,
+            wavsServiceManagerImpl,
+            abi.encodeCall(WavsServiceManager.initialize, (msg.sender, msg.sender))
+        );
+        UpgradeableProxyLib.upgrade(stakeRegistry, stakeRegistryImpl);
+        UpgradeableProxyLib.upgradeAndCall(
+            registryCoordinator,
+            registryCoordinatorImpl,
+            abi.encodeCall(
+                SlashingRegistryCoordinator.initialize,
+                (msg.sender, msg.sender, msg.sender, 0, wavsServiceManager)
+            )
+        );
+        UpgradeableProxyLib.upgrade(blsApkRegistry, blsApkRegistryImpl);
+        UpgradeableProxyLib.upgrade(indexRegistry, indexRegistryImpl);
+        UpgradeableProxyLib.upgrade(socketRegistry, socketRegistryImpl);
+
+        return DeploymentData({
+            wavsServiceManager: wavsServiceManager,
+            stakeRegistry: stakeRegistry,
+            registryCoordinator: registryCoordinator,
+            blsApkRegistry: blsApkRegistry,
+            indexRegistry: indexRegistry,
+            socketRegistry: socketRegistry,
+            pauserRegistry: pauserRegistry
+        });
+    }
+
+    function configureContracts(
+        DeploymentData memory deployment,
+        IStakeRegistryTypes.StrategyParams[] memory strategyParams,
+        string memory metadataUri,
+        address allocationManagerAddress,
+        address permissionControllerAddress,
+        uint96 minimumWeight
+    ) internal {
+        // set avs registrar
+        WavsServiceManager wavsServiceManager = WavsServiceManager(deployment.wavsServiceManager);
+        wavsServiceManager.setAppointee(
+            deployment.registryCoordinator,
+            allocationManagerAddress,
+            bytes4(keccak256("createOperatorSets(address,(uint32,address[])[])"))
+        );
+
+        wavsServiceManager.updateAVSMetadataURI(metadataUri);
+
+        ISlashingRegistryCoordinator slashingRegistryCoordinator =
+            ISlashingRegistryCoordinator(deployment.registryCoordinator);
+        slashingRegistryCoordinator.createTotalDelegatedStakeQuorum(
+            ISlashingRegistryCoordinatorTypes.OperatorSetParam({
+                maxOperatorCount: 100,
+                kickBIPsOfOperatorStake: 10_500,
+                kickBIPsOfTotalStake: 100
+            }),
+            minimumWeight,
+            strategyParams
+        );
+
+        wavsServiceManager.addPendingAdmin(msg.sender);
+        IPermissionController permissionController =
+            IPermissionController(permissionControllerAddress);
+        permissionController.acceptAdmin(deployment.wavsServiceManager);
+
+        IAllocationManager allocationManager = IAllocationManager(allocationManagerAddress);
+        allocationManager.setAVSRegistrar(
+            deployment.wavsServiceManager, IAVSRegistrar(deployment.registryCoordinator)
+        );
+    }
+
+    function readStrategyParamsConfig(
+        string memory fileName
+    ) internal returns (IStakeRegistryTypes.StrategyParams[] memory) {
+        if (!VM.exists(fileName)) {
+            revert WavsMiddlewareDeploymentLib__StrategiesFileNotFound();
+        }
+
+        // load the strategies config
+        string memory json = VM.readFile(fileName);
+        address[] memory strategies = abi.decode(VM.parseJson(json, ".strategies"), (address[]));
+        uint96[] memory multipliers = abi.decode(VM.parseJson(json, ".multipliers"), (uint96[]));
+        if (strategies.length != multipliers.length) {
+            revert WavsMiddlewareDeploymentLib__StrategiesAndMultipliersLengthMismatch();
+        }
+
+        // convert to quorum
+        uint256 size = strategies.length;
+        uint256 totalMultiplier = 0;
+        IStakeRegistryTypes.StrategyParams[] memory strategyParams =
+            new IStakeRegistryTypes.StrategyParams[](size);
+        for (uint256 i; i < size; i++) {
+            totalMultiplier += multipliers[i];
+            strategyParams[i] = IStakeRegistryTypes.StrategyParams({
+                strategy: IStrategy(strategies[i]),
+                multiplier: multipliers[i]
+            });
+        }
+        if (totalMultiplier != 10_000) {
+            revert WavsMiddlewareDeploymentLib__TotalMultiplierNot10000();
+        }
+
+        return strategyParams;
+    }
+
+    // function readDeploymentJson(
+    //     string memory directoryPath,
+    //     uint256 chainId
+    // ) internal returns (DeploymentData memory) {
+    //     string memory fileName = string.concat(directoryPath, VM.toString(chainId), ".json");
+
+    //     if (!VM.exists(fileName)) {
+    //         revert WavsMiddlewareDeploymentLib__DeploymentFileNotFound();
+    //     }
+
+    //     string memory json = VM.readFile(fileName);
+
+    //     DeploymentData memory data;
+    //     /// TODO: 2 Step for reading deployment json.  Read to the core and the AVS data
+    //     data.wavsServiceManager = json.readAddress(".contracts.wavsServiceManager");
+    //     data.stakeRegistry = json.readAddress(".contracts.stakeRegistry");
+    //     data.strategy = json.readAddress(".contracts.strategy");
+    //     data.avsRegistrar = json.readAddress(".contracts.avsRegistrar");
+
+    //     return data;
+    // }
+
+    function writeDeploymentJson(
+        string memory outputPath,
+        uint256 chainId,
+        DeploymentData memory data
+    ) internal {
+        address proxyAdmin = address(UpgradeableProxyLib.getProxyAdmin(data.wavsServiceManager));
+
+        string memory deploymentData = _generateDeploymentJson(data, proxyAdmin);
+
+        string memory fileName = string.concat(outputPath, VM.toString(chainId), ".json");
+        if (!VM.exists(outputPath)) {
+            VM.createDir(outputPath, true);
+        }
+
+        VM.writeFile(fileName, deploymentData);
+        console2.log("Deployment artifacts written to:", fileName);
+    }
+
+    function _generateDeploymentJson(
+        DeploymentData memory data,
+        address proxyAdmin
+    ) private view returns (string memory) {
+        return string.concat(
+            "{",
+            "\"lastUpdate\":{",
+            "\"timestamp\":\"",
+            VM.toString(block.timestamp),
+            "\",",
+            "\"block_number\":\"",
+            VM.toString(block.number),
+            "\"",
+            "},",
+            "\"addresses\":",
+            _generateContractsJson(data, proxyAdmin),
+            "}"
+        );
+    }
+
+    function _generateContractsJson(
+        DeploymentData memory data,
+        address proxyAdmin
+    ) private view returns (string memory) {
+        return string.concat(
+            "{\"proxyAdmin\":\"",
+            proxyAdmin.toHexString(),
+            "\",\"wavsServiceManager\":\"",
+            data.wavsServiceManager.toHexString(),
+            "\",\"wavsServiceManagerImpl\":\"",
+            data.wavsServiceManager.getImplementation().toHexString(),
+            "\",\"stakeRegistry\":\"",
+            data.stakeRegistry.toHexString(),
+            "\",\"stakeRegistryImpl\":\"",
+            data.stakeRegistry.getImplementation().toHexString(),
+            "\",\"registryCoordinator\":\"",
+            data.registryCoordinator.toHexString(),
+            "\",\"registryCoordinatorImpl\":\"",
+            data.registryCoordinator.getImplementation().toHexString(),
+            "\",\"blsApkRegistry\":\"",
+            data.blsApkRegistry.toHexString(),
+            "\",\"blsApkRegistryImpl\":\"",
+            data.blsApkRegistry.getImplementation().toHexString(),
+            "\",\"indexRegistry\":\"",
+            data.indexRegistry.toHexString(),
+            "\",\"indexRegistryImpl\":\"",
+            data.indexRegistry.getImplementation().toHexString(),
+            "\",\"socketRegistry\":\"",
+            data.socketRegistry.toHexString(),
+            "\",\"socketRegistryImpl\":\"",
+            data.socketRegistry.getImplementation().toHexString(),
+            "\",\"pauserRegistry\":\"",
+            data.pauserRegistry.toHexString(),
+            "\"}"
+        );
+    }
+}

--- a/contracts/src/eigenlayer/bls/WavsAVSRegistrar.sol
+++ b/contracts/src/eigenlayer/bls/WavsAVSRegistrar.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import {IAVSRegistrar} from "@eigenlayer/contracts/interfaces/IAVSRegistrar.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+// Minimal AVS Registrar contract.
+// It allows the owner to pause the registration, preventing all Operator register and deregister operations.
+contract WavsAVSRegistrar is IAVSRegistrar, Ownable {
+    bool public isPaused;
+
+    error WavsAVSRegistrar__Paused();
+
+    constructor() Ownable() {
+        isPaused = false;
+    }
+
+    function pause() external onlyOwner {
+        isPaused = true;
+    }
+
+    function unpause() external onlyOwner {
+        isPaused = false;
+    }
+
+    modifier notPaused() {
+        if (isPaused) {
+            revert WavsAVSRegistrar__Paused();
+        }
+        _;
+    }
+
+    function registerOperator(
+        address operator,
+        address avs,
+        uint32[] calldata operatorSetIds,
+        bytes calldata data
+    ) external override notPaused {
+        // TODO: Implement registration logic
+    }
+
+    function deregisterOperator(
+        address operator,
+        address avs,
+        uint32[] calldata operatorSetIds
+    ) external override notPaused {
+        // TODO: Implement deregistration logic
+    }
+
+    function supportsAVS(
+        address /* avs */
+    ) external pure override returns (bool) {
+        // TODO: Implement logic to check if AVS is supported
+        return true; // Placeholder return value
+    }
+
+    fallback() external {}
+}

--- a/contracts/src/eigenlayer/bls/WavsServiceManager.sol
+++ b/contracts/src/eigenlayer/bls/WavsServiceManager.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import {ServiceManagerBase} from "@eigenlayer-middleware/src/ServiceManagerBase.sol";
+import {IAVSDirectory} from "@eigenlayer/contracts/interfaces/IAVSDirectory.sol";
+import {IRewardsCoordinator} from "@eigenlayer/contracts/interfaces/IRewardsCoordinator.sol";
+import {ISlashingRegistryCoordinator} from
+    "@eigenlayer-middleware/src/interfaces/ISlashingRegistryCoordinator.sol";
+import {IStakeRegistry} from "@eigenlayer-middleware/src/interfaces/IStakeRegistry.sol";
+import {IPermissionController} from "@eigenlayer/contracts/interfaces/IPermissionController.sol";
+import {IAllocationManager} from "@eigenlayer/contracts/interfaces/IAllocationManager.sol";
+
+import {IWavsServiceManager} from "./interfaces/IWavsServiceManager.sol";
+
+contract WavsServiceManager is ServiceManagerBase, IWavsServiceManager {
+    string public serviceURI;
+    uint256 public quorumNumerator;
+    uint256 public quorumDenominator;
+
+    constructor(
+        address __avsDirectory,
+        address __rewardsCoordinator,
+        address __registryCoordinator,
+        address __stakeRegistry,
+        address __permissionController,
+        address __allocationManager
+    )
+        ServiceManagerBase(
+            IAVSDirectory(__avsDirectory),
+            IRewardsCoordinator(__rewardsCoordinator),
+            ISlashingRegistryCoordinator(__registryCoordinator),
+            IStakeRegistry(__stakeRegistry),
+            IPermissionController(__permissionController),
+            IAllocationManager(__allocationManager)
+        )
+    {}
+
+    function initialize(address initialOwner, address rewardsInitiator) external initializer {
+        __ServiceManagerBase_init(initialOwner, rewardsInitiator);
+
+        quorumNumerator = 2;
+        quorumDenominator = 3;
+    }
+
+    /// @notice Slashes an operator
+    function slashOperator(
+        IAllocationManager.SlashingParams memory params
+    ) external {
+        // Implementation logic here
+    }
+
+    function setServiceURI(
+        string calldata _serviceURI
+    ) external onlyOwner {
+        serviceURI = _serviceURI;
+        emit ServiceURIUpdated(_serviceURI);
+    }
+
+    function getServiceURI() external view returns (string memory) {
+        return serviceURI;
+    }
+
+    function setQuorumThreshold(uint256 numerator, uint256 denominator) external onlyOwner {
+        if (numerator == 0) {
+            revert InvalidQuorumParameters();
+        }
+        if (denominator == 0) {
+            revert InvalidQuorumParameters();
+        }
+        if (numerator > denominator) {
+            revert InvalidQuorumParameters();
+        }
+
+        quorumNumerator = numerator;
+        quorumDenominator = denominator;
+
+        emit QuorumThresholdUpdated(numerator, denominator);
+    }
+
+    /**
+     * @notice Updates the metadata URI for the AVS
+     * @param _metadataURI is the metadata URI for the AVS
+     * @dev only callable by the owner
+     */
+    function updateAVSMetadataURI(
+        string memory _metadataURI
+    ) public override onlyOwner {
+        _avsDirectory.updateAVSMetadataURI(_metadataURI);
+        _allocationManager.updateAVSMetadataURI(address(this), _metadataURI);
+    }
+}

--- a/contracts/src/eigenlayer/bls/interfaces/IWavsServiceManager.sol
+++ b/contracts/src/eigenlayer/bls/interfaces/IWavsServiceManager.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+interface IWavsServiceManager {
+    error InvalidQuorumParameters();
+
+    // ------------------------------------------------------------------------
+    // Events
+    // ------------------------------------------------------------------------
+    event ServiceURIUpdated(string serviceURI);
+    event QuorumThresholdUpdated(uint256 numerator, uint256 denominator);
+
+    /**
+     * @notice Returns the service URI.
+     * @return The service URI.
+     */
+    function getServiceURI() external view returns (string memory);
+
+    /**
+     * @notice Updates the service URI.
+     * @param _serviceURI The service URI to update.
+     */
+    function setServiceURI(
+        string calldata _serviceURI
+    ) external;
+
+    /**
+     * @notice Sets a new quorum threshold for signature validation
+     * @param numerator The numerator of the quorum fraction
+     * @param denominator The denominator of the quorum fraction
+     * @dev The fraction numerator/denominator represents the minimum portion of stake
+     *      required for a valid signature (e.g., 2/3 or 51/100)
+     */
+    function setQuorumThreshold(uint256 numerator, uint256 denominator) external;
+}

--- a/contracts/test/eigenlayer/bls/WavsAVSRegistrar.t.sol
+++ b/contracts/test/eigenlayer/bls/WavsAVSRegistrar.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+
+import {WavsAVSRegistrar} from "src/eigenlayer/bls/WavsAVSRegistrar.sol";
+
+contract WavsAVSRegistrarTest is Test {
+    WavsAVSRegistrar public registrar;
+    address public owner = makeAddr("owner");
+    address public nonOwner = makeAddr("non-owner");
+
+    function setUp() public {
+        vm.startPrank(owner);
+        registrar = new WavsAVSRegistrar();
+        vm.stopPrank();
+    }
+
+    function test_initial_state() public view {
+        // Test initial state
+        assertEq(registrar.isPaused(), false, "Initial state should be unpaused");
+        assertEq(registrar.owner(), owner, "Owner should be set correctly");
+    }
+
+    function test_pause() public {
+        // Test pause functionality
+        vm.prank(owner);
+        registrar.pause();
+        assertTrue(registrar.isPaused(), "Contract should be paused");
+    }
+
+    function test_unpause() public {
+        // First pause the contract
+        vm.prank(owner);
+        registrar.pause();
+
+        // Then unpause it
+        vm.prank(owner);
+        registrar.unpause();
+        assertFalse(registrar.isPaused(), "Contract should be unpaused");
+    }
+
+    function test_only_owner_can_pause() public {
+        // Non-owner should not be able to pause
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        registrar.pause();
+    }
+
+    function test_only_owner_can_unpause() public {
+        // First pause the contract
+        vm.prank(owner);
+        registrar.pause();
+
+        // Non-owner should not be able to unpause
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        registrar.unpause();
+    }
+
+    function test_registerOperator_works() public {
+        address operator = address(0x123);
+        address avs = address(0x456);
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = 1;
+        bytes memory data = "test data";
+
+        // Should not revert when not paused
+        registrar.registerOperator(operator, avs, operatorSetIds, data);
+        assertTrue(true, "registerOperator should not revert when not paused");
+
+        vm.prank(owner);
+        registrar.pause();
+
+        // Should revert with pause message when paused
+        vm.expectRevert(abi.encodeWithSelector(WavsAVSRegistrar.WavsAVSRegistrar__Paused.selector));
+        registrar.registerOperator(operator, avs, operatorSetIds, data);
+    }
+
+    function test_deregisterOperator_works() public {
+        address operator = address(0x123);
+        address avs = address(0x456);
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = 1;
+
+        // Should not revert when not paused
+        registrar.deregisterOperator(operator, avs, operatorSetIds);
+        assertTrue(true, "deregisterOperator should not revert when not paused");
+
+        vm.prank(owner);
+        registrar.pause();
+
+        // Should revert with pause message when paused
+        vm.expectRevert(abi.encodeWithSelector(WavsAVSRegistrar.WavsAVSRegistrar__Paused.selector));
+        registrar.deregisterOperator(operator, avs, operatorSetIds);
+    }
+}

--- a/contracts/test/eigenlayer/bls/WavsServiceManager.t.sol
+++ b/contracts/test/eigenlayer/bls/WavsServiceManager.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import {WavsServiceManager} from "src/eigenlayer/bls/WavsServiceManager.sol";
+import {IWavsServiceManager} from "src/eigenlayer/bls/interfaces/IWavsServiceManager.sol";
+
+contract WavsServiceManagerTest is Test {
+    WavsServiceManager public serviceManager;
+    address public owner = makeAddr("owner");
+    address public proxyOwner = makeAddr("proxyOwner");
+
+    address public avsDirectory = makeAddr("avsDirectory");
+    address public rewardsCoordinator = makeAddr("rewardsCoordinator");
+    address public registryCoordinator = makeAddr("registryCoordinator");
+    address public stakeRegistry = makeAddr("stakeRegistry");
+    address public permissionController = makeAddr("permissionController");
+    address public allocationManager = makeAddr("allocationManager");
+
+    function setUp() public {
+        // Set the owner as the caller for all subsequent calls in this test
+        vm.startPrank(owner);
+
+        // Deploy the implementation contract
+        WavsServiceManager implementation = new WavsServiceManager(
+            avsDirectory,
+            rewardsCoordinator,
+            registryCoordinator,
+            stakeRegistry,
+            permissionController,
+            allocationManager
+        );
+        vm.stopPrank();
+
+        vm.startPrank(proxyOwner);
+        // Deploy the proxy and initialize it
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(implementation),
+            proxyOwner,
+            abi.encodeWithSelector(WavsServiceManager.initialize.selector, owner, owner)
+        );
+        serviceManager = WavsServiceManager(address(proxy));
+        vm.stopPrank();
+    }
+
+    function test_initial_state() public view {
+        // Test initial state
+        assertEq(serviceManager.quorumNumerator(), 2, "Initial quorum numerator should be 2");
+        assertEq(serviceManager.quorumDenominator(), 3, "Initial quorum denominator should be 3");
+        assertEq(serviceManager.avsDirectory(), avsDirectory, "AVS directory should be set");
+    }
+
+    function test_setQuorumThreshold() public {
+        // Change quorum to 51%
+        vm.startPrank(owner);
+        serviceManager.setQuorumThreshold(51, 100);
+        vm.stopPrank();
+
+        assertEq(serviceManager.quorumNumerator(), 51, "Quorum numerator should be updated");
+        assertEq(serviceManager.quorumDenominator(), 100, "Quorum denominator should be updated");
+    }
+
+    function test_setQuorumThreshold_only_owner() public {
+        // Non-owner should not be able to set quorum threshold
+        vm.prank(makeAddr("non-owner"));
+        vm.expectRevert("Ownable: caller is not the owner");
+        serviceManager.setQuorumThreshold(1, 2);
+    }
+
+    function test_setQuorumThreshold_invalid_params() public {
+        // numerator = 0
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IWavsServiceManager.InvalidQuorumParameters.selector)
+        );
+        serviceManager.setQuorumThreshold(0, 2);
+
+        // denominator = 0
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IWavsServiceManager.InvalidQuorumParameters.selector)
+        );
+        serviceManager.setQuorumThreshold(1, 0);
+
+        // numerator > denominator
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IWavsServiceManager.InvalidQuorumParameters.selector)
+        );
+        serviceManager.setQuorumThreshold(3, 2);
+    }
+
+    function test_setServiceURI() public {
+        vm.startPrank(owner);
+        serviceManager.setServiceURI("https://wavs.io");
+        vm.stopPrank();
+
+        assertEq(serviceManager.getServiceURI(), "https://wavs.io", "Service URI should be updated");
+
+        vm.startPrank(makeAddr("non-owner"));
+        vm.expectRevert("Ownable: caller is not the owner");
+        serviceManager.setServiceURI("https://wavs.io");
+        vm.stopPrank();
+    }
+}

--- a/scripts/bls/eigen/deploy.sh
+++ b/scripts/bls/eigen/deploy.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# -x echos all lines for debug
+# set -x
+
+set -o errexit -o nounset -o pipefail
+command -v shellcheck >/dev/null && shellcheck "$0"
+
+SCRIPT_DIR="$(realpath "$(dirname "$0")")"
+# shellcheck source=../../helper.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../../helper.sh"
+
+# Parse command line arguments in key=value format
+parse_args "$@"
+
+# Check required environment variables (secrets) - no defaults for security
+check_env_var "FUNDED_KEY" "${FUNDED_KEY:-}"
+
+# Check required parameters (can be from env or command line) with defaults
+check_param "METADATA_URI" "${METADATA_URI:-}"
+check_param "DEPLOY_ENV" "${DEPLOY_ENV:-LOCAL}"
+
+# Set up environment based on DEPLOY_ENV
+setup_environment
+
+# Get chain ID from RPC endpoint
+CHAIN_ID=$(get_chain_id)
+export CHAIN_ID
+echo "Detected chain ID: $CHAIN_ID"
+
+#############################################
+###### Start of script execution ############
+#############################################
+
+# Create necessary directories
+ensure_dir "$HOME/.nodes"
+
+# Get deployer address and save private key
+deployer_address=$(cast wallet address "$FUNDED_KEY")
+save_deployment_data "$HOME/.nodes/deployer" "$FUNDED_KEY"
+
+# Ensure deployer has sufficient balance
+ensure_balance "$deployer_address"
+
+echo "Deployer address: $deployer_address configured for $DEPLOY_ENV environment"
+
+cd contracts || handle_error "Failed to change to contracts directory"
+forge script script/eigenlayer/bls/WavsMiddlewareDeployer.s.sol --rpc-url "$LOCAL_ETHEREUM_RPC_URL" --private-key "$FUNDED_KEY" -vvv --broadcast || handle_error "Failed to deploy WavsMiddlewareDeployer"
+
+echo "BLS contracts deployed with addresses:"
+cat deployments/wavs-middleware/$CHAIN_ID.json | jq .addresses
+
+# Save deployment data
+cp deployments/wavs-middleware/$CHAIN_ID.json "$HOME/.nodes/avs_deploy.json"


### PR DESCRIPTION
Fixes on #157 

- Add simple WavsServiceManager.
- Solidity script for deployment of `proxyAdmin`, `wavsServiceManager`, `stakeRegistry`, `registryCoordinator`, `blsApkRegistry`, `indexRegistry`, `socketRegistry`, `pauserRegistry`, `avsRegistrar`.
- Shell script for docker deploy
- Updated README.md