### PR TITLE
191 Allocation Manager Read Function and Operator Set ID

### DIFF
--- a/contracts/script/eigenlayer/ecdsa/WavsListOperators.s.sol
+++ b/contracts/script/eigenlayer/ecdsa/WavsListOperators.s.sol
@@ -80,8 +80,8 @@ contract WavsListOperators is Script {
         uint256 thresholdWeight = stakeRegistry.getLastCheckpointThresholdWeight();
 
         IAllocationManager allocationManager =
-            IAllocationManager(serviceManager.allocationManager());
-        OperatorSet memory opSetQuery = OperatorSet({avs: address(serviceManager), id: 1});
+            IAllocationManager(serviceManager.getAllocationManager());
+        OperatorSet memory opSetQuery = OperatorSet({avs: address(serviceManager), id: 0});
         address[] memory operators = allocationManager.getMembers(opSetQuery);
 
         uint256[] memory weights = new uint256[](operators.length);

--- a/contracts/script/eigenlayer/ecdsa/WavsMirrorListOperators.s.sol
+++ b/contracts/script/eigenlayer/ecdsa/WavsMirrorListOperators.s.sol
@@ -85,8 +85,8 @@ contract WavsMirrorListOperators is Script {
         WavsServiceManager sourceServiceManager = WavsServiceManager(sourceServiceManagerAddress);
 
         IAllocationManager allocationManager =
-            IAllocationManager(sourceServiceManager.allocationManager());
-        OperatorSet memory opSetQuery = OperatorSet({avs: sourceServiceManagerAddress, id: 1});
+            IAllocationManager(sourceServiceManager.getAllocationManager());
+        OperatorSet memory opSetQuery = OperatorSet({avs: sourceServiceManagerAddress, id: 0});
         address[] memory operators = allocationManager.getMembers(opSetQuery);
 
         // Create mirror chain fork and get stake information

--- a/contracts/script/eigenlayer/ecdsa/utils/WavsMiddlewareDeploymentLib.sol
+++ b/contracts/script/eigenlayer/ecdsa/utils/WavsMiddlewareDeploymentLib.sol
@@ -116,7 +116,7 @@ library WavsMiddlewareDeploymentLib {
         // Suggestion - use same both for opset and for initialize. But which one (or both)?
         //             ECDSAStakeRegistry.initialize, (result.WavsServiceManager, 100, quorum) // TODO: dynamically update threshold (?)
         IAllocationManagerTypes.CreateSetParams memory opSetParams = IAllocationManagerTypes
-            .CreateSetParams({operatorSetId: 1, strategies: new IStrategy[](1)});
+            .CreateSetParams({operatorSetId: 0, strategies: new IStrategy[](1)});
         opSetParams.strategies[0] = IStrategy(deployment.strategy);
         IAllocationManagerTypes.CreateSetParams[] memory opSetParamsArray =
             new IAllocationManagerTypes.CreateSetParams[](1);

--- a/contracts/script/eigenlayer/ecdsa/utils/WavsMirrorDeploymentLib.sol
+++ b/contracts/script/eigenlayer/ecdsa/utils/WavsMirrorDeploymentLib.sol
@@ -228,8 +228,8 @@ library WavsMirrorDeploymentLib {
 
         // get operators
         IAllocationManager allocationManager =
-            IAllocationManager(serviceManager.allocationManager());
-        OperatorSet memory opSetQuery = OperatorSet({avs: serviceManagerAddress, id: 1});
+            IAllocationManager(serviceManager.getAllocationManager());
+        OperatorSet memory opSetQuery = OperatorSet({avs: serviceManagerAddress, id: 0});
         cfg.operators = allocationManager.getMembers(opSetQuery);
 
         // get operator info

--- a/contracts/script/eigenlayer/ecdsa/utils/WavsRegisterOperatorLib.sol
+++ b/contracts/script/eigenlayer/ecdsa/utils/WavsRegisterOperatorLib.sol
@@ -102,20 +102,20 @@ library WavsRegisterOperatorLib {
 
         //  query if already in opset and add if if not in it yet.
         IAllocationManager allocationManager =
-            IAllocationManager(serviceManager.allocationManager());
-        OperatorSet memory opSetQuery = OperatorSet({avs: serviceManagerAddress, id: 1});
+            IAllocationManager(serviceManager.getAllocationManager());
+        OperatorSet memory opSetQuery = OperatorSet({avs: serviceManagerAddress, id: 0});
         if (!allocationManager.isMemberOfOperatorSet(operatorAddr, opSetQuery)) {
             uint32[] memory opSetIds = new uint32[](1);
-            opSetIds[0] = 1;
+            opSetIds[0] = 0;
             // TODO: change this arbitrary code?
             bytes memory secretCode = bytes("0x1234");
             IAllocationManagerTypes.RegisterParams memory params = IAllocationManagerTypes
                 .RegisterParams({avs: serviceManagerAddress, operatorSetIds: opSetIds, data: secretCode});
             allocationManager.registerForOperatorSets(operatorAddr, params);
 
-            console2.log("Successfully registered operator %s to operator sets [1]", operatorAddr);
+            console2.log("Successfully registered operator %s to operator sets [0]", operatorAddr);
         } else {
-            console2.log("%s already registered to operator sets [1]", operatorAddr);
+            console2.log("%s already registered to operator sets [0]", operatorAddr);
         }
 
         if (!stakeRegistry.operatorRegistered(operatorAddr)) {
@@ -181,11 +181,11 @@ library WavsRegisterOperatorLib {
 
         // query if already in opset and add if if not in it yet.
         IAllocationManager allocationManager =
-            IAllocationManager(serviceManager.allocationManager());
-        OperatorSet memory opSetQuery = OperatorSet({avs: serviceManagerAddress, id: 1});
+            IAllocationManager(serviceManager.getAllocationManager());
+        OperatorSet memory opSetQuery = OperatorSet({avs: serviceManagerAddress, id: 0});
         if (allocationManager.isMemberOfOperatorSet(operatorAddr, opSetQuery)) {
             uint32[] memory opSetIds = new uint32[](1);
-            opSetIds[0] = 1;
+            opSetIds[0] = 0;
             IAllocationManagerTypes.DeregisterParams memory params = IAllocationManagerTypes
                 .DeregisterParams({
                 operator: operatorAddr,
@@ -195,10 +195,10 @@ library WavsRegisterOperatorLib {
             allocationManager.deregisterFromOperatorSets(params);
 
             console2.log(
-                "Successfully deregistered operator %s from operator sets [1]", operatorAddr
+                "Successfully deregistered operator %s from operator sets [0]", operatorAddr
             );
         } else {
-            console2.log("%s not registered to operator sets [1]", operatorAddr);
+            console2.log("%s not registered to operator sets [0]", operatorAddr);
         }
 
         if (stakeRegistry.operatorRegistered(operatorAddr)) {

--- a/contracts/src/eigenlayer/ecdsa/WavsServiceManager.sol
+++ b/contracts/src/eigenlayer/ecdsa/WavsServiceManager.sol
@@ -307,7 +307,13 @@ contract WavsServiceManager is ECDSAServiceManagerBase, IWavsServiceManager {
         return ECDSAStakeRegistry(stakeRegistry).getLatestOperatorForSigningKey(signingKeyAddress);
     }
 
+    /// @inheritdoc IWavsServiceManager
     function getDelegationManager() external view returns (address) {
         return delegationManager;
+    }
+
+    /// @inheritdoc IWavsServiceManager
+    function getAllocationManager() external view returns (address) {
+        return allocationManager;
     }
 }

--- a/contracts/src/eigenlayer/ecdsa/interfaces/IWavsServiceManager.sol
+++ b/contracts/src/eigenlayer/ecdsa/interfaces/IWavsServiceManager.sol
@@ -62,4 +62,16 @@ interface IWavsServiceManager {
     function getLatestOperatorForSigningKey(
         address signingKeyAddress
     ) external view returns (address);
+
+    /**
+     * @notice Retrieves the allocation manager address.
+     * @return The allocation manager address.
+     */
+    function getAllocationManager() external view returns (address);
+
+    /**
+     * @notice Retrieves the delegation manager address.
+     * @return The delegation manager address.
+     */
+    function getDelegationManager() external view returns (address);
 }

--- a/contracts/src/eigenlayer/ecdsa/mocks/SimpleServiceManager.sol
+++ b/contracts/src/eigenlayer/ecdsa/mocks/SimpleServiceManager.sol
@@ -117,4 +117,12 @@ contract SimpleServiceManager is IWavsServiceManager {
     ) external pure override returns (address) {
         return signingKeyAddress;
     }
+
+    function getDelegationManager() external view returns (address) {
+        return address(0);
+    }
+
+    function getAllocationManager() external view returns (address) {
+        return address(0);
+    }
 }


### PR DESCRIPTION
Fixes on #191 , following up https://github.com/Lay3rLabs/wavs-tools/pull/93

- Add `getAllocationManager` read function.
- Update OpeartorSet id to 0.