### PR TITLE
test(e2e): docci integration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,45 @@
+name: DEV E2E
+
+on:
+#   push:
+#     branches:
+#       - main
+  pull_request:
+  workflow_dispatch:
+
+# Ensures that only a single workflow per PR will run at a time. Cancels in-progress jobs if new commit is pushed.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      DEBUGGING: true
+      RUST_BACKTRACE: 1
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Install Ubuntu packages
+      run: sudo apt-get update && sudo apt-get install bash make jq
+
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: stable
+
+    - name: Install Docci Readme Runner
+      run: |
+        VERSION=v0.9.0-alpha.2
+        wget -O docci.tar.gz "https://github.com/Reecepbcups/docci/releases/download/${VERSION}/docci_Linux_x86_64.tar.gz"
+        tar -xzf docci.tar.gz
+        sudo mv docci /usr/local/bin/docci
+        sudo chmod +x /usr/local/bin/docci
+        rm docci.tar.gz
+
+    - run: docci run DEV.md --cleanup-commands="killall anvil" --hide-background-logs

--- a/DEV.md
+++ b/DEV.md
@@ -22,7 +22,7 @@ docker build -t wavs-middleware .
 
 start holesky fork:
 
-```bash
+```bash docci-background docci-delay-after=2
 RPC_URL=https://ethereum-holesky-rpc.publicnode.com
 anvil --fork-url $RPC_URL --host 0.0.0.0 --port 8545
 ```
@@ -73,7 +73,7 @@ docker run --rm --network host -v ./.nodes:/root/.nodes \
 
 list operators:
 
-```bash
+```bash docci-output-contains="Operator 1:"
 docker run --rm --network host -v ./.nodes:/root/.nodes \
   wavs-middleware list_operators
 ```
@@ -122,13 +122,13 @@ docker run --rm --network host -v ./.nodes:/root/.nodes \
 
 mirror chain start
 
-```bash
+```bash docci-delay-after=2 docci-background
 anvil --host 0.0.0.0 --port 8546
 ```
 
 mirror deploy
 
-```bash
+```bash docci-delay-after=2
 WAVS_SERVICE_MANAGER_ADDRESS=`jq -r .addresses.WavsServiceManager .nodes/avs_deploy.json`
 
 docker run --rm --network host -v ./.nodes:/root/.nodes \
@@ -139,14 +139,23 @@ docker run --rm --network host -v ./.nodes:/root/.nodes \
 
 mirror list operators
 
-```bash
+```bash docci-ignore docci-output-contains="Operator 1:"
+SOURCE_RPC_URL=http://localhost:8545
+MIRROR_RPC_URL=http://localhost:8546
+WAVS_SERVICE_MANAGER_ADDRESS=`jq -r .addresses.WavsServiceManager .nodes/avs_deploy.json`
+MIRROR_SERVICE_MANAGER_ADDRESS=`jq -r .addresses.WavsServiceManager .nodes/mirror.json`
+
 docker run --rm --network host -v ./.nodes:/root/.nodes \
+   -e SOURCE_SERVICE_MANAGER_ADDRESS=${WAVS_SERVICE_MANAGER_ADDRESS} \
+   -e MIRROR_SERVICE_MANAGER_ADDRESS=${MIRROR_SERVICE_MANAGER_ADDRESS} \
+   -e SOURCE_RPC_URL=${SOURCE_RPC_URL} \
+   -e MIRROR_RPC_URL=${MIRROR_RPC_URL} \
   wavs-middleware -m mirror list_operators
 ```
 
 mock deploy
 
-```bash
+```bash docci-ignore
 LOCAL_CONFIG_PATH=$(pwd)/mock-config.json
 
 MOCK_DEPLOYER_KEY=$(cast wallet new --json | jq -r '.[0].private_key')


### PR DESCRIPTION
Builds on top of https://github.com/Lay3rLabs/wavs-middleware/pull/198

## Summary

Ethan mentioned before Berlin that it was a pain for him to have to manually run the markdown to verify changes.

This integrates [Docci](https://github.com/Reecepbcups/docci), a tool I wrote that turns your markdown files into testsuites without writing any code (just these markdown tags), just context. I also use this in the [wavs-bridge](https://github.com/Lay3rLabs/wavs-bridge/pull/56) as well.

It will catch any commands with non 0 exit status (perfect for `set -e` scripts), or if the stdout/err does not contain the desired text. useful to have general sanity checks along the way. including echo'ing a variable and making sure its set.