### PR TITLE
renaming refactor and avs-sync handler addition

### DIFF
--- a/contracts/script/eigenlayer/ecdsa/WavsMiddlewareDeployer.s.sol
+++ b/contracts/script/eigenlayer/ecdsa/WavsMiddlewareDeployer.s.sol
@@ -47,6 +47,8 @@ contract WavsMiddlewareDeployer is Script, IECDSAStakeRegistryTypes {
     error WavsMiddlewareDeployer__DelegationManagerAddressCannotBeZero();
     /// @notice The error for the AVS directory address cannot be zero.
     error WavsMiddlewareDeployer__AVSDirectoryAddressCannotBeZero();
+    /// @notice The error for the operator update handler address cannot be zero.
+    error WavsMiddlewareDeployer__OperatorUpdateHandlerAddressCannotBeZero();
 
     /// @notice The setup function for the script.
     function setUp() public virtual {
@@ -96,6 +98,9 @@ contract WavsMiddlewareDeployer is Script, IECDSAStakeRegistryTypes {
         }
         if (wavsMiddlewareDeployment.strategy == address(0)) {
             revert WavsMiddlewareDeployer__StrategyAddressCannotBeZero();
+        }
+        if (wavsMiddlewareDeployment.operatorUpdateHandler == address(0)) {
+            revert WavsMiddlewareDeployer__OperatorUpdateHandlerAddressCannotBeZero();
         }
         if (proxyAdmin == address(0)) {
             revert WavsMiddlewareDeployer__ProxyAdminAddressCannotBeZero();

--- a/contracts/script/eigenlayer/ecdsa/WavsMirrorDeployer.s.sol
+++ b/contracts/script/eigenlayer/ecdsa/WavsMirrorDeployer.s.sol
@@ -29,10 +29,10 @@ contract WavsMirrorDeployer is Script, IECDSAStakeRegistryTypes {
     error WavsMirrorDeployer__StakeRegistryAddressCannotBeZero();
     /// @notice The error for the WAVS service manager address cannot be zero.
     error WavsMirrorDeployer__WavsServiceManagerAddressCannotBeZero();
-    /// @notice The error for the mirror service handler address cannot be zero.
-    error WavsMirrorDeployer__MirrorServiceHandlerAddressCannotBeZero();
-    /// @notice The error for the mirror service manager handler address cannot be zero.
-    error WavsMirrorDeployer__MirrorServiceManagerHandlerAddressCannotBeZero();
+    /// @notice The error for the operator sync handler address cannot be zero.
+    error WavsMirrorDeployer__OperatorSyncHandlerAddressCannotBeZero();
+    /// @notice The error for the quorum sync handler address cannot be zero.
+    error WavsMirrorDeployer__QuorumSyncHandlerAddressCannotBeZero();
     /// @notice The error for the proxy admin address cannot be zero.
     error WavsMirrorDeployer__ProxyAdminAddressCannotBeZero();
     /// @notice The error for the no operators.
@@ -79,11 +79,11 @@ contract WavsMirrorDeployer is Script, IECDSAStakeRegistryTypes {
         if (deployment.wavsServiceManager == address(0)) {
             revert WavsMirrorDeployer__WavsServiceManagerAddressCannotBeZero();
         }
-        if (deployment.mirrorServiceHandler == address(0)) {
-            revert WavsMirrorDeployer__MirrorServiceHandlerAddressCannotBeZero();
+        if (deployment.operatorSyncHandler == address(0)) {
+            revert WavsMirrorDeployer__OperatorSyncHandlerAddressCannotBeZero();
         }
-        if (deployment.mirrorServiceManagerHandler == address(0)) {
-            revert WavsMirrorDeployer__MirrorServiceManagerHandlerAddressCannotBeZero();
+        if (deployment.quorumSyncHandler == address(0)) {
+            revert WavsMirrorDeployer__QuorumSyncHandlerAddressCannotBeZero();
         }
         if (proxyAdmin == address(0)) {
             revert WavsMirrorDeployer__ProxyAdminAddressCannotBeZero();

--- a/contracts/script/eigenlayer/ecdsa/utils/WavsMiddlewareDeploymentLib.sol
+++ b/contracts/script/eigenlayer/ecdsa/utils/WavsMiddlewareDeploymentLib.sol
@@ -18,6 +18,8 @@ import {UpgradeableProxyLib} from "./UpgradeableProxyLib.sol";
 import {WavsServiceManager} from "src/eigenlayer/ecdsa/WavsServiceManager.sol";
 import {ReadCoreLib} from "./ReadCoreLib.sol";
 import {WavsAVSRegistrar} from "src/eigenlayer/ecdsa/WavsAVSRegistrar.sol";
+import {WavsOperatorUpdateHandler} from
+    "src/eigenlayer/ecdsa/handlers/WavsOperatorUpdateHandler.sol";
 
 /**
  * @title WavsMiddlewareDeploymentLib
@@ -36,12 +38,14 @@ library WavsMiddlewareDeploymentLib {
      * @param stakeRegistry The stake registry address.
      * @param strategy The strategy address.
      * @param avsRegistrar The AVS registrar address.
+     * @param operatorUpdateHandler The operator update handler address.
      */
     struct DeploymentData {
         address wavsServiceManager;
         address stakeRegistry;
         address strategy;
         address avsRegistrar;
+        address operatorUpdateHandler;
     }
 
     /**
@@ -64,6 +68,8 @@ library WavsMiddlewareDeploymentLib {
     error WavsMiddlewareDeploymentLib__StrategiesAndMultipliersLengthMismatch();
     /// @notice The error for the total multiplier not 10000.
     error WavsMiddlewareDeploymentLib__TotalMultiplierNot10000();
+    /// @notice The error for the service handlers already deployed.
+    error WavsMiddlewareDeploymentLib__ServiceHandlersAlreadyDeployed();
 
     /**
      * @notice The deploy contracts function.
@@ -119,6 +125,15 @@ library WavsMiddlewareDeploymentLib {
         // Dummy AVSRegistrar deployment for now
         address avsRegistrar = address(new WavsAVSRegistrar());
         result.avsRegistrar = avsRegistrar;
+
+        // deploy the operator update handler
+        address operatorUpdateHandler = address(
+            new WavsOperatorUpdateHandler(
+                WavsServiceManager(result.wavsServiceManager),
+                ECDSAStakeRegistry(result.stakeRegistry)
+            )
+        );
+        result.operatorUpdateHandler = operatorUpdateHandler;
 
         return result;
     }
@@ -248,6 +263,7 @@ library WavsMiddlewareDeploymentLib {
         data.stakeRegistry = json.readAddress(".contracts.stakeRegistry");
         data.strategy = json.readAddress(".contracts.strategy");
         data.avsRegistrar = json.readAddress(".contracts.avsRegistrar");
+        data.operatorUpdateHandler = json.readAddress(".contracts.operatorUpdateHandler");
 
         return data;
     }
@@ -307,7 +323,8 @@ library WavsMiddlewareDeploymentLib {
         DeploymentData memory data,
         address proxyAdmin
     ) private view returns (string memory) {
-        return string.concat(
+        // split up into two parts to avoid Yul exception too deep in stack error during build
+        string memory first = string.concat(
             "{\"proxyAdmin\":\"",
             proxyAdmin.toHexString(),
             "\",\"WavsServiceManager\":\"",
@@ -317,11 +334,17 @@ library WavsMiddlewareDeploymentLib {
             "\",\"stakeRegistry\":\"",
             data.stakeRegistry.toHexString(),
             "\",\"stakeRegistryImpl\":\"",
-            data.stakeRegistry.getImplementation().toHexString(),
+            data.stakeRegistry.getImplementation().toHexString()
+        );
+
+        return string.concat(
+            first,
             "\",\"strategy\":\"",
             data.strategy.toHexString(),
             "\",\"avsRegistrar\":\"",
             data.avsRegistrar.toHexString(),
+            "\",\"operatorUpdateHandler\":\"",
+            data.operatorUpdateHandler.toHexString(),
             "\"}"
         );
     }

--- a/contracts/script/eigenlayer/ecdsa/utils/WavsMirrorDeploymentLib.sol
+++ b/contracts/script/eigenlayer/ecdsa/utils/WavsMirrorDeploymentLib.sol
@@ -15,9 +15,9 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {MirrorStakeRegistry} from "src/eigenlayer/ecdsa/MirrorStakeRegistry.sol";
-import {MirrorServiceHandler} from "src/eigenlayer/ecdsa/handlers/MirrorServiceHandler.sol";
-import {MirrorServiceManagerHandler} from
-    "src/eigenlayer/ecdsa/handlers/MirrorServiceManagerHandler.sol";
+import {MirrorOperatorSyncHandler} from
+    "src/eigenlayer/ecdsa/handlers/MirrorOperatorSyncHandler.sol";
+import {MirrorQuorumSyncHandler} from "src/eigenlayer/ecdsa/handlers/MirrorQuorumSyncHandler.sol";
 import {WavsServiceManager} from "src/eigenlayer/ecdsa/WavsServiceManager.sol";
 import {UpgradeableProxyLib} from "./UpgradeableProxyLib.sol";
 
@@ -52,14 +52,14 @@ library WavsMirrorDeploymentLib {
      * @notice The deployment data struct.
      * @param wavsServiceManager The WAVS service manager address.
      * @param stakeRegistry The stake registry address.
-     * @param mirrorServiceHandler The mirror service handler address.
-     * @param mirrorServiceManagerHandler The mirror service manager handler address.
+     * @param operatorSyncHandler The operator sync handler address.
+     * @param quorumSyncHandler The quorum sync handler address.
      */
     struct DeploymentData {
         address wavsServiceManager;
         address stakeRegistry;
-        address mirrorServiceHandler;
-        address mirrorServiceManagerHandler;
+        address operatorSyncHandler;
+        address quorumSyncHandler;
     }
 
     Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
@@ -177,24 +177,23 @@ library WavsMirrorDeploymentLib {
         DeploymentData memory deployment
     ) internal returns (DeploymentData memory) {
         if (
-            deployment.mirrorServiceHandler != address(0)
-                || deployment.mirrorServiceManagerHandler != address(0)
+            deployment.operatorSyncHandler != address(0)
+                || deployment.quorumSyncHandler != address(0)
         ) {
             revert WavsMirrorDeploymentLib__ServiceHandlersAlreadyDeployed();
         }
 
         DeploymentData memory result = deployment;
 
-        // deploy the stake registry handler
+        // deploy the operator sync handler
         MirrorStakeRegistry stakeRegistry = MirrorStakeRegistry(result.stakeRegistry);
-        result.mirrorServiceHandler = address(new MirrorServiceHandler(stakeRegistry));
-        stakeRegistry.transferOwnership(result.mirrorServiceHandler);
+        result.operatorSyncHandler = address(new MirrorOperatorSyncHandler(stakeRegistry));
+        stakeRegistry.transferOwnership(result.operatorSyncHandler);
 
-        // deploy the service manager handler
+        // deploy the quorum sync handler
         WavsServiceManager serviceManager = WavsServiceManager(result.wavsServiceManager);
-        result.mirrorServiceManagerHandler =
-            address(new MirrorServiceManagerHandler(serviceManager));
-        serviceManager.transferOwnership(result.mirrorServiceManagerHandler);
+        result.quorumSyncHandler = address(new MirrorQuorumSyncHandler(serviceManager));
+        serviceManager.transferOwnership(result.quorumSyncHandler);
 
         return result;
     }
@@ -323,9 +322,8 @@ library WavsMirrorDeploymentLib {
         DeploymentData memory data;
         data.wavsServiceManager = json.readAddress(".contracts.wavsServiceManager");
         data.stakeRegistry = json.readAddress(".contracts.stakeRegistry");
-        data.mirrorServiceHandler = json.readAddress(".contracts.mirrorServiceHandler");
-        data.mirrorServiceManagerHandler =
-            json.readAddress(".contracts.mirrorServiceManagerHandler");
+        data.operatorSyncHandler = json.readAddress(".contracts.operatorSyncHandler");
+        data.quorumSyncHandler = json.readAddress(".contracts.quorumSyncHandler");
 
         return data;
     }
@@ -396,10 +394,10 @@ library WavsMirrorDeploymentLib {
             data.stakeRegistry.toHexString(),
             "\",\"stakeRegistryImpl\":\"",
             data.stakeRegistry.getImplementation().toHexString(),
-            "\",\"MirrorServiceHandler\":\"",
-            data.mirrorServiceHandler.toHexString(),
-            "\",\"MirrorServiceManagerHandler\":\"",
-            data.mirrorServiceManagerHandler.toHexString(),
+            "\",\"operatorSyncHandler\":\"",
+            data.operatorSyncHandler.toHexString(),
+            "\",\"quorumSyncHandler\":\"",
+            data.quorumSyncHandler.toHexString(),
             "\"}"
         );
     }

--- a/contracts/src/eigenlayer/ecdsa/handlers/MirrorOperatorSyncHandler.sol
+++ b/contracts/src/eigenlayer/ecdsa/handlers/MirrorOperatorSyncHandler.sol
@@ -4,15 +4,15 @@ pragma solidity ^0.8.27;
 import {IWavsServiceHandler} from "../interfaces/IWavsServiceHandler.sol";
 import {IWavsServiceManager} from "../interfaces/IWavsServiceManager.sol";
 import {MirrorStakeRegistry} from "../MirrorStakeRegistry.sol";
-import {IMirrorUpdateTypes} from "../interfaces/IMirrorServiceHandler.sol";
+import {IMirrorOperatorSyncHandler} from "../interfaces/IMirrorOperatorSyncHandler.sol";
 
 /**
- * @title MirrorServiceHandler
+ * @title MirrorOperatorSyncHandler
  * @author Lay3r Labs
- * @notice Contract for handling the Mirror service
- * @dev This contract implements the IWavsServiceHandler interface
+ * @notice Contract for syncing operator details from the source chain to the mirror chain
+ * @dev This contract implements the IMirrorOperatorSyncHandler and IWavsServiceHandler interfaces
  */
-contract MirrorServiceHandler is IMirrorUpdateTypes, IWavsServiceHandler {
+contract MirrorOperatorSyncHandler is IMirrorOperatorSyncHandler, IWavsServiceHandler {
     /// @notice Ensures all updates are deployed in order and no duplicates.
     uint64 public lastTriggerId;
 

--- a/contracts/src/eigenlayer/ecdsa/handlers/MirrorQuorumSyncHandler.sol
+++ b/contracts/src/eigenlayer/ecdsa/handlers/MirrorQuorumSyncHandler.sol
@@ -3,15 +3,15 @@ pragma solidity ^0.8.27;
 
 import {IWavsServiceHandler} from "../interfaces/IWavsServiceHandler.sol";
 import {WavsServiceManager} from "../WavsServiceManager.sol";
-import {IManagerUpdateTypes} from "../interfaces/IMirrorServiceManagerHandler.sol";
+import {IMirrorQuorumSyncHandler} from "../interfaces/IMirrorQuorumSyncHandler.sol";
 
 /**
- * @title MirrorServiceManagerHandler
+ * @title MirrorQuorumSyncHandler
  * @author Lay3r Labs
- * @notice Contract for handling the Mirror service manager
- * @dev This contract implements the IManagerUpdateTypes and IWavsServiceHandler interfaces
+ * @notice Contract for syncing quorum details from the source chain to the mirror chain
+ * @dev This contract implements the IMirrorQuorumSyncHandler and IWavsServiceHandler interfaces
  */
-contract MirrorServiceManagerHandler is IManagerUpdateTypes, IWavsServiceHandler {
+contract MirrorQuorumSyncHandler is IMirrorQuorumSyncHandler, IWavsServiceHandler {
     /// @notice Ensures all updates are deployed in order and no duplicates.
     uint64 public lastTriggerId;
 

--- a/contracts/src/eigenlayer/ecdsa/handlers/README.md
+++ b/contracts/src/eigenlayer/ecdsa/handlers/README.md
@@ -1,0 +1,23 @@
+# ECDSA Service Handlers
+
+This directory contains service handlers that need to be deployed with the middleware contracts and are used by external WAVS services that keep various pieces of state up to date. These services are critical to ensuring that changes in the operator set, quorum configuration, and stake registry are synchronized throughout the system.
+
+Both of the mirror handlers are only necessary when data is being submitted to non-Ethereum chains, since they keep the mirror middleware in sync with the service deployment on Ethereum.
+
+## WavsOperatorUpdateHandler
+
+This handler updates operator weights in the stake registry to reflect changes in EigenLayer's operator set.
+
+Used by `operator-updater` service.
+
+## MirrorOperatorSyncHandler
+
+This handler syncs operator info (registrations, signing keys, etc.) and stake thresholds from the service deployment on Ethereum to other chains (with the mirror middleware) that need to be able to verify operator signatures during WAVS submission.
+
+Used by `multi-chain-operator-sync` service.
+
+## MirrorQuorumSyncHandler
+
+This handler syncs the quorum threshold from the service deployment on Ethereum to other chains (with the mirror middleware) that need to be able to verify operator signatures during WAVS submission.
+
+Used by `multi-chain-quorum-sync` service.

--- a/contracts/src/eigenlayer/ecdsa/handlers/WavsOperatorUpdateHandler.sol
+++ b/contracts/src/eigenlayer/ecdsa/handlers/WavsOperatorUpdateHandler.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {ECDSAStakeRegistry} from "@eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol";
+import {IWavsServiceHandler} from "../interfaces/IWavsServiceHandler.sol";
+import {WavsServiceManager} from "../WavsServiceManager.sol";
+import {IWavsOperatorUpdateHandler} from "../interfaces/IWavsOperatorUpdateHandler.sol";
+
+/**
+ * @title WavsOperatorUpdateHandler
+ * @author Lay3r Labs
+ * @notice Contract for syncing operator weights from the
+ * @dev This contract implements the IMirrorQuorumSyncHandler and IWavsServiceHandler interfaces
+ */
+contract WavsOperatorUpdateHandler is IWavsOperatorUpdateHandler, IWavsServiceHandler {
+    /// @notice Service manager instance
+    WavsServiceManager public immutable SERVICE_MANAGER;
+
+    /// @notice ECDSA stake registry instance
+    ECDSAStakeRegistry public immutable ECDSA_STAKE_REGISTRY;
+
+    /**
+     * @notice Constructor
+     * @param _serviceManager The service manager instance
+     * @param _ecdsaStakeRegistry The ECDSA stake registry instance
+     */
+    constructor(WavsServiceManager _serviceManager, ECDSAStakeRegistry _ecdsaStakeRegistry) {
+        SERVICE_MANAGER = _serviceManager;
+        ECDSA_STAKE_REGISTRY = _ecdsaStakeRegistry;
+    }
+
+    /// @inheritdoc IWavsServiceHandler
+    function handleSignedEnvelope(
+        Envelope calldata envelope,
+        SignatureData calldata signatureData
+    ) external {
+        SERVICE_MANAGER.validate(envelope, signatureData);
+
+        OperatorUpdatePayload memory payload = abi.decode(envelope.payload, (OperatorUpdatePayload));
+
+        //NOTE: any block limits we should worry about here?
+        //NOTE: writer go code uses retry mechanism for this: https://github.com/Layr-Labs/eigenlayer-middleware/blob/3fb5b61076475108bd87d4e6c7352fd60b46af1c/src/interfaces/ISlashingRegistryCoordinator.sol#L362-L363
+        ECDSA_STAKE_REGISTRY.updateOperatorsForQuorum(
+            payload.operatorsPerQuorum, payload.quorumNumbers
+        );
+    }
+
+    /// @inheritdoc IWavsServiceHandler
+    function getServiceManager() external view returns (address) {
+        return address(SERVICE_MANAGER);
+    }
+
+    /**
+     * @notice Returns the address of the ECDSA stake registry
+     * @return The address of the ECDSA stake registry
+     */
+    function getStakeRegistry() external view returns (address) {
+        return address(ECDSA_STAKE_REGISTRY);
+    }
+}

--- a/contracts/src/eigenlayer/ecdsa/interfaces/IMirrorOperatorSyncHandler.sol
+++ b/contracts/src/eigenlayer/ecdsa/interfaces/IMirrorOperatorSyncHandler.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.27;
 
 /**
- * @title IMirrorUpdateTypes
+ * @title IMirrorOperatorSyncHandler
  * @author Lay3r Labs
- * @notice Interface for the Mirror update types
- * @dev This interface defines the update types for the Mirror service
+ * @notice Interface for the operator sync handler
+ * @dev This interface defines the types for the operator sync handler
  */
-interface IMirrorUpdateTypes {
+interface IMirrorOperatorSyncHandler {
     /// @notice The error for the invalid trigger ID.
     error InvalidTriggerId(uint64 expectedTriggerId);
 

--- a/contracts/src/eigenlayer/ecdsa/interfaces/IMirrorQuorumSyncHandler.sol
+++ b/contracts/src/eigenlayer/ecdsa/interfaces/IMirrorQuorumSyncHandler.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.27;
 
 /**
- * @title IManagerUpdateTypes
+ * @title IMirrorQuorumSyncHandler
  * @author Lay3r Labs
- * @notice Interface for the manager update types
- * @dev This interface defines the update types for the manager
+ * @notice Interface for the quorum sync handler
+ * @dev This interface defines the types for the quorum sync handler
  */
-interface IManagerUpdateTypes {
+interface IMirrorQuorumSyncHandler {
     /// @notice The error for the invalid trigger ID.
     error InvalidTriggerId(uint64 expectedTriggerId);
 

--- a/contracts/src/eigenlayer/ecdsa/interfaces/IWavsOperatorUpdateHandler.sol
+++ b/contracts/src/eigenlayer/ecdsa/interfaces/IWavsOperatorUpdateHandler.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+/**
+ * @title IWavsOperatorUpdateHandler
+ * @author Lay3r Labs
+ * @notice Interface for the operator weight sync handler
+ * @dev This interface defines the types for the operator weight sync handler
+ */
+interface IWavsOperatorUpdateHandler {
+    /**
+     * @notice OperatorUpdatePayload is a struct containing the operators to update
+     * @param operatorsPerQuorum The operators per quorum
+     * @param quorumNumbers The quorum numbers
+     */
+    struct OperatorUpdatePayload {
+        address[][] operatorsPerQuorum;
+        bytes quorumNumbers;
+    }
+}

--- a/contracts/test/eigenlayer/ecdsa/MirrorOperatorSyncHandler.t.sol
+++ b/contracts/test/eigenlayer/ecdsa/MirrorOperatorSyncHandler.t.sol
@@ -1,0 +1,488 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {ECDSAUpgradeable} from
+    "@openzeppelin-upgrades/contracts/utils/cryptography/ECDSAUpgradeable.sol";
+
+import {WavsMirrorDeploymentLib} from "script/eigenlayer/ecdsa/utils/WavsMirrorDeploymentLib.sol";
+import {UpgradeableProxyLib} from "script/eigenlayer/ecdsa/utils/UpgradeableProxyLib.sol";
+import {MirrorStakeRegistry} from "src/eigenlayer/ecdsa/MirrorStakeRegistry.sol";
+import {WavsServiceManager} from "src/eigenlayer/ecdsa/WavsServiceManager.sol";
+import {
+    MirrorOperatorSyncHandler,
+    IMirrorOperatorSyncHandler
+} from "src/eigenlayer/ecdsa/handlers/MirrorOperatorSyncHandler.sol";
+import {IWavsServiceHandler} from "src/eigenlayer/ecdsa/interfaces/IWavsServiceHandler.sol";
+
+/**
+ * @title MirrorOperatorSyncHandlerTest
+ * @author Lay3rLabs
+ * @notice This contract contains tests for the MirrorOperatorSyncHandler contract.
+ * @dev This contract is used to test the MirrorOperatorSyncHandler contract.
+ */
+contract MirrorOperatorSyncHandlerTest is Test {
+    using UpgradeableProxyLib for address;
+
+    // Constants
+    uint256 private constant OPERATOR_WEIGHT = 10_000;
+
+    address private deployer;
+    address private proxyAdmin;
+
+    // Contract references
+    MirrorStakeRegistry private stakeRegistry;
+    WavsServiceManager private serviceManager;
+    MirrorOperatorSyncHandler private serviceHandler;
+
+    // Basic operator data
+    address[] private operators;
+    address[] private signingKeyAddresses;
+    uint256[] private weights;
+    uint256[] private privateKeys;
+
+    error MirrorOperatorSyncHandlerTest__BlockNumberTooLowForOffset();
+    error MirrorOperatorSyncHandlerTest__ArraysLengthMismatch();
+    error MirrorOperatorSyncHandlerTest__SignatureRecoveryFailed();
+
+    /// @notice The setUp function.
+    function setUp() public {
+        // Set up deployer address
+        deployer = address(0x123);
+        vm.startPrank(deployer);
+
+        // Deploy proxy admin
+        proxyAdmin = UpgradeableProxyLib.deployProxyAdmin();
+
+        // Deploy contracts
+        WavsMirrorDeploymentLib.DeploymentData memory deployment =
+            WavsMirrorDeploymentLib.deployContracts(proxyAdmin);
+
+        // Create references to deployed contracts
+        serviceManager = WavsServiceManager(deployment.wavsServiceManager);
+        stakeRegistry = MirrorStakeRegistry(deployment.stakeRegistry);
+
+        vm.stopPrank();
+
+        // Create test info for 5 operators
+        privateKeys = new uint256[](5);
+        operators = new address[](5);
+        signingKeyAddresses = new address[](5);
+        weights = new uint256[](5);
+
+        for (uint256 i = 0; i < 5; ++i) {
+            privateKeys[i] = i + 1;
+            operators[i] = vm.addr(privateKeys[i]);
+            signingKeyAddresses[i] = vm.addr(privateKeys[i]);
+            weights[i] = OPERATOR_WEIGHT;
+        }
+
+        // Find out the actual owner of the contracts
+        address actualOwner = serviceManager.owner();
+
+        // Set up test operator weights as the actual owner
+        vm.startPrank(actualOwner);
+        stakeRegistry.batchSetOperatorDetails(operators, signingKeyAddresses, weights);
+        vm.stopPrank();
+
+        // Deploy MirrorOperatorSyncHandler
+        vm.startPrank(actualOwner);
+        deployment = WavsMirrorDeploymentLib.deployServiceHandlers(deployment);
+        serviceHandler = MirrorOperatorSyncHandler(deployment.operatorSyncHandler);
+        vm.stopPrank();
+
+        // Roll to block 10 to ensure we have enough blocks for reference blocks
+        vm.roll(10);
+    }
+
+    /* solhint-disable func-name-mixedcase */
+    /// @notice The test_initial_state function.
+    function test_initial_state() public view {
+        /* solhint-enable func-name-mixedcase */
+        // Verify deployment addresses are set correctly
+        assertNotEq(address(serviceHandler), address(0), "ServiceHandler address cannot be zero");
+
+        // Verify contract references
+        assertEq(
+            address(serviceHandler.getStakeRegistry()),
+            address(stakeRegistry),
+            "ServiceHandler should reference correct StakeRegistry"
+        );
+
+        assertEq(
+            address(serviceHandler.getServiceManager()),
+            address(serviceManager),
+            "ServiceHandler should reference correct ServiceManager"
+        );
+
+        // Verify initial trigger ID is 0
+        assertEq(serviceHandler.lastTriggerId(), 0, "Initial trigger ID should be 0");
+
+        // Verify that the owner of the stakeRegistry is the serviceHandler
+        assertEq(
+            stakeRegistry.owner(),
+            address(serviceHandler),
+            "ServiceHandler should be the owner of stakeRegistry"
+        );
+    }
+
+    /* solhint-disable func-name-mixedcase */
+    /// @notice The test_invalid_payload function.
+    function test_invalid_payload() public {
+        /* solhint-enable func-name-mixedcase */
+        // Create an envelope with invalid payload
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(1)),
+            ordering: bytes12(0),
+            payload: abi.encode("Bad payload")
+        });
+
+        // Create signature data with 4 operators (more than enough to pass quorum)
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 4, 5);
+
+        // Call handleSignedEnvelope should fail with invalid payload
+        vm.expectRevert();
+        serviceHandler.handleSignedEnvelope(envelope, signatureData);
+    }
+
+    /* solhint-disable func-name-mixedcase */
+    /// @notice The test_invalid_trigger_id function.
+    function test_invalid_trigger_id() public {
+        /* solhint-enable func-name-mixedcase */
+        // Keep the same operators
+        address[] memory newOperators = operators;
+        address[] memory newSigningKeyAddresses = signingKeyAddresses;
+        uint256[] memory newWeights = weights;
+
+        // Update to triggerId 5
+        IMirrorOperatorSyncHandler.UpdateWithId memory updateData = IMirrorOperatorSyncHandler
+            .UpdateWithId({
+            triggerId: 5,
+            thresholdWeight: 5000,
+            operators: newOperators,
+            signingKeyAddresses: newSigningKeyAddresses,
+            weights: newWeights
+        });
+        // Create envelope with the encoded payload
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(1)),
+            ordering: bytes12(0),
+            payload: abi.encode(updateData)
+        });
+
+        // Create signature data with 4 operators (more than enough to pass quorum)
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 4, 5);
+        // Will pass and update to 5
+        serviceHandler.handleSignedEnvelope(envelope, signatureData);
+
+        // ensure it is updated
+        assertEq(serviceHandler.lastTriggerId(), 5, "Initial trigger ID should be 5");
+
+        // Try again will fail (reply)
+        vm.expectRevert(
+            abi.encodeWithSelector(IMirrorOperatorSyncHandler.InvalidTriggerId.selector, 5)
+        );
+        serviceHandler.handleSignedEnvelope(envelope, signatureData);
+
+        // Previous trigger id will fail
+        updateData = IMirrorOperatorSyncHandler.UpdateWithId({
+            triggerId: 3, // 3 < 5
+            thresholdWeight: 5000,
+            operators: newOperators,
+            signingKeyAddresses: newSigningKeyAddresses,
+            weights: newWeights
+        });
+        // Create envelope with the encoded payload
+        envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(2)),
+            ordering: bytes12(0),
+            payload: abi.encode(updateData)
+        });
+        // Create signature data with 4 operators (more than enough to pass quorum)
+        signatureData = createSignatureData(envelope, 4, 5);
+
+        // but fails
+        vm.expectRevert(
+            abi.encodeWithSelector(IMirrorOperatorSyncHandler.InvalidTriggerId.selector, 5)
+        );
+        serviceHandler.handleSignedEnvelope(envelope, signatureData);
+    }
+
+    /* solhint-disable func-name-mixedcase */
+    /// @notice The test_insufficient_quorum function.
+    function test_insufficient_quorum() public {
+        /* solhint-enable func-name-mixedcase */
+        // Create a valid UpdateWithId payload with triggerId = 1
+        address[] memory newOperators = new address[](1);
+        address[] memory newSigningKeyAddresses = new address[](1);
+        uint256[] memory newWeights = new uint256[](1);
+
+        newOperators[0] = address(0x123);
+        newSigningKeyAddresses[0] = address(0x456);
+        newWeights[0] = 10_000;
+
+        // Create the UpdateWithId struct with triggerId = 1
+        IMirrorOperatorSyncHandler.UpdateWithId memory updateData = IMirrorOperatorSyncHandler
+            .UpdateWithId({
+            triggerId: 1,
+            thresholdWeight: 5000,
+            operators: newOperators,
+            signingKeyAddresses: newSigningKeyAddresses,
+            weights: newWeights
+        });
+
+        // Create envelope with the encoded payload
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(1)),
+            ordering: bytes12(0),
+            payload: abi.encode(updateData)
+        });
+
+        // Create signature data with only 3 operators (not enough for quorum)
+        // The quorum is 4/5 (80%) in the default setup
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 3, 5);
+
+        // Call handleSignedEnvelope should fail with InsufficientQuorum
+        // Note: The actual error will come from the serviceManager.validate() call inside handleSignedEnvelope
+        // which will revert with InsufficientQuorum error
+        // The actual values are slightly different due to integer division in the contract
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "InsufficientQuorum(uint256,uint256,uint256)",
+                30_000, // 3/5 * 10000 = 6000 (but in basis points, so 30000)
+                33_333, // 1/3 in basis points (rounded up from 33333.33...)
+                50_000 // 1/2 in basis points (due to integer math in the contract)
+            )
+        );
+        serviceHandler.handleSignedEnvelope(envelope, signatureData);
+    }
+
+    /* solhint-disable func-name-mixedcase */
+    /// @notice The test_successful_update_weight function.
+    function test_successful_update_weight() public {
+        /* solhint-enable func-name-mixedcase */
+        // let's change the weights and a public key
+        // now op1 and op2 have 2/3 and can pass a future round
+        address[] memory newOperators = new address[](2);
+        address[] memory newSigningKeyAddresses = new address[](2);
+        uint256[] memory newWeights = new uint256[](2);
+
+        // after this, we have 30k, 30k, 10k, 10k, 10k
+        for (uint256 i = 0; i < 2; ++i) {
+            newOperators[i] = operators[i];
+            newSigningKeyAddresses[i] = signingKeyAddresses[i];
+            newWeights[i] = OPERATOR_WEIGHT * 3;
+        }
+
+        // Create the UpdateWithId struct with triggerId = 1
+        IMirrorOperatorSyncHandler.UpdateWithId memory updateData = IMirrorOperatorSyncHandler
+            .UpdateWithId({
+            triggerId: 1,
+            thresholdWeight: 8000,
+            operators: newOperators,
+            signingKeyAddresses: newSigningKeyAddresses,
+            weights: newWeights
+        });
+
+        // Create envelope with the encoded payload
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(1)),
+            ordering: bytes12(0),
+            payload: abi.encode(updateData)
+        });
+
+        // 4/5 can pass this with > 2/3
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 4, 0);
+        serviceHandler.handleSignedEnvelope(envelope, signatureData);
+
+        // Check that the lastTriggerId was incremented
+        assertEq(
+            stakeRegistry.getLastCheckpointThresholdWeight(), 8000, "stakeThreshold not updated"
+        );
+        assertEq(serviceHandler.lastTriggerId(), 1, "lastTriggerId not incremented");
+
+        // Move forward in blocks to ensure the previous update is finalized
+        uint256 startBlock = vm.getBlockNumber();
+        uint256 stepOne = startBlock + 10;
+        vm.roll(stepOne + 1);
+
+        // Check the weights were updated at the block of the first update
+        for (uint256 i = 0; i < 2; ++i) {
+            uint256 weight =
+                stakeRegistry.getOperatorWeightAtBlock(newOperators[i], uint32(stepOne));
+            assertEq(weight, newWeights[i], "Operator weight not updated");
+        }
+
+        uint256 totalWeight = stakeRegistry.getLastCheckpointTotalWeightAtBlock(uint32(stepOne));
+        assertEq(totalWeight, 90_000, "Total weight not updated");
+
+        newOperators = new address[](3);
+        newSigningKeyAddresses = new address[](3);
+        newWeights = new uint256[](3);
+
+        // Set up the next update - setting weights to 0 for the last 3 operators
+        for (uint256 i = 0; i < 3; ++i) {
+            newOperators[i] = operators[i + 2];
+            newSigningKeyAddresses[i] = signingKeyAddresses[i + 2];
+            newWeights[i] = 0;
+        }
+
+        // Create the UpdateWithId struct with triggerId = 2
+        updateData = IMirrorOperatorSyncHandler.UpdateWithId({
+            triggerId: 2,
+            thresholdWeight: 6500,
+            operators: newOperators,
+            signingKeyAddresses: newSigningKeyAddresses,
+            weights: newWeights
+        });
+
+        // Create envelope with the encoded payload
+        envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(1)),
+            ordering: bytes12(0),
+            payload: abi.encode(updateData)
+        });
+
+        // First 2 operators now have 2/3 and can pass
+        signatureData = createSignatureData(envelope, 2, 0);
+
+        // Call handleSignedEnvelope
+        serviceHandler.handleSignedEnvelope(envelope, signatureData);
+
+        // Move forward in blocks to ensure the previous update is finalized
+        uint256 stepTwo = startBlock + 20;
+        vm.roll(stepTwo + 1);
+
+        // Check that the lastTriggerId was incremented
+        assertEq(
+            stakeRegistry.getLastCheckpointThresholdWeight(), 6500, "stakeThreshold not updated"
+        );
+        assertEq(serviceHandler.lastTriggerId(), 2, "lastTriggerId not incremented to 2");
+
+        uint256 newTotalWeight = stakeRegistry.getLastCheckpointTotalWeightAtBlock(uint32(stepTwo));
+        assertEq(newTotalWeight, 60_000, "Total weight not updated");
+
+        // Check that the operator weights were properly updated (0s for the other operators)
+        for (uint256 i = 0; i < 3; ++i) {
+            uint256 weight =
+                stakeRegistry.getOperatorWeightAtBlock(newOperators[i], uint32(stepTwo));
+            assertEq(weight, 0, "Operator weight not set to 0");
+        }
+    }
+
+    /**
+     * @notice The createSignatureData function.
+     * @param envelope The envelope.
+     * @param numOperators The number of operators.
+     * @param referenceBlockOffset The reference block offset.
+     * @return The signature data.
+     */
+    function createSignatureData(
+        IWavsServiceHandler.Envelope memory envelope,
+        uint256 numOperators,
+        uint32 referenceBlockOffset
+    ) internal view returns (IWavsServiceHandler.SignatureData memory) {
+        // Create digest using the same logic as WavsServiceManager
+        bytes32 message = keccak256(abi.encode(envelope));
+        bytes32 digest = ECDSAUpgradeable.toEthSignedMessageHash(message);
+
+        // Create signature data with the desired number of signers
+        address[] memory signers = new address[](numOperators);
+        bytes[] memory signatures = new bytes[](numOperators);
+
+        for (uint256 i = 0; i < numOperators; ++i) {
+            // Generate signer address from private key
+            signers[i] = vm.addr(privateKeys[i]);
+
+            // Generate signature using private key
+            signatures[i] = generateSignature(privateKeys[i], digest);
+        }
+
+        // Sort signers and signatures by signer address11
+        sortSignersAndSignatures(signers, signatures);
+
+        // Verify signatures
+        verifySignatures(digest, signers, signatures);
+
+        // Create signature data
+        // Note: referenceBlock must be a valid block that exists and is in the past
+        // Make sure we're at least at block 1 before subtracting offset
+        uint32 currentBlock = uint32(block.number);
+        if (!(currentBlock > referenceBlockOffset)) {
+            revert MirrorOperatorSyncHandlerTest__BlockNumberTooLowForOffset();
+        }
+
+        return IWavsServiceHandler.SignatureData({
+            signers: signers,
+            signatures: signatures,
+            referenceBlock: currentBlock - 1 - referenceBlockOffset
+        });
+    }
+
+    /**
+     * @notice The sortSignersAndSignatures function.
+     * @dev ECDSAStakeRegistry requires signers to be sorted in ascending order
+     * @param signers Array of signer addresses
+     * @param signatures Array of signatures that correspond to signers at the same index
+     */
+    function sortSignersAndSignatures(
+        address[] memory signers,
+        bytes[] memory signatures
+    ) internal pure {
+        // Simple bubble sort since we're working with small arrays
+        uint256 length = signers.length;
+        for (uint256 i = 0; i < length - 1; ++i) {
+            for (uint256 j = 0; j < length - i - 1; ++j) {
+                if (signers[j] > signers[j + 1]) {
+                    // Swap signers
+                    address tempAddr = signers[j];
+                    signers[j] = signers[j + 1];
+                    signers[j + 1] = tempAddr;
+
+                    // Swap corresponding signatures
+                    bytes memory tempSig = signatures[j];
+                    signatures[j] = signatures[j + 1];
+                    signatures[j + 1] = tempSig;
+                }
+            }
+        }
+    }
+
+    /**
+     * @notice The generateSignature function.
+     * @param privateKey The private key to sign with
+     * @param digest The message hash to sign
+     * @return The signature in bytes format ready for validation
+     */
+    function generateSignature(
+        uint256 privateKey,
+        bytes32 digest
+    ) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    /**
+     * @notice The verifySignatures function.
+     * @param digest Message hash that was signed
+     * @param signers Array of signer addresses (should be sorted)
+     * @param signatures Array of signatures corresponding to signers
+     */
+    function verifySignatures(
+        bytes32 digest,
+        address[] memory signers,
+        bytes[] memory signatures
+    ) internal pure {
+        if (signers.length != signatures.length) {
+            revert MirrorOperatorSyncHandlerTest__ArraysLengthMismatch();
+        }
+
+        for (uint256 i = 0; i < signers.length; ++i) {
+            address recovered = ECDSA.recover(digest, signatures[i]);
+            if (recovered != signers[i]) {
+                revert MirrorOperatorSyncHandlerTest__SignatureRecoveryFailed();
+            }
+        }
+    }
+}

--- a/contracts/test/eigenlayer/ecdsa/MirrorQuorumSyncHandler.t.sol
+++ b/contracts/test/eigenlayer/ecdsa/MirrorQuorumSyncHandler.t.sol
@@ -11,18 +11,18 @@ import {UpgradeableProxyLib} from "script/eigenlayer/ecdsa/utils/UpgradeableProx
 import {MirrorStakeRegistry} from "src/eigenlayer/ecdsa/MirrorStakeRegistry.sol";
 import {WavsServiceManager} from "src/eigenlayer/ecdsa/WavsServiceManager.sol";
 import {
-    MirrorServiceHandler,
-    IMirrorUpdateTypes
-} from "src/eigenlayer/ecdsa/handlers/MirrorServiceHandler.sol";
+    MirrorQuorumSyncHandler,
+    IMirrorQuorumSyncHandler
+} from "src/eigenlayer/ecdsa/handlers/MirrorQuorumSyncHandler.sol";
 import {IWavsServiceHandler} from "src/eigenlayer/ecdsa/interfaces/IWavsServiceHandler.sol";
 
 /**
- * @title MirrorServiceHandlerTest
+ * @title MirrorQuorumSyncHandlerTest
  * @author Lay3rLabs
- * @notice This contract contains tests for the MirrorServiceHandler contract.
- * @dev This contract is used to test the MirrorServiceHandler contract.
+ * @notice This contract contains tests for the MirrorQuorumSyncHandler contract.
+ * @dev This contract is used to test the MirrorQuorumSyncHandler contract.
  */
-contract MirrorServiceHandlerTest is Test {
+contract MirrorQuorumSyncHandlerTest is Test {
     using UpgradeableProxyLib for address;
 
     // Constants
@@ -30,11 +30,12 @@ contract MirrorServiceHandlerTest is Test {
 
     address private deployer;
     address private proxyAdmin;
+    WavsMirrorDeploymentLib.DeploymentData private deployment;
 
     // Contract references
     MirrorStakeRegistry private stakeRegistry;
     WavsServiceManager private serviceManager;
-    MirrorServiceHandler private serviceHandler;
+    MirrorQuorumSyncHandler private serviceHandler;
 
     // Basic operator data
     address[] private operators;
@@ -42,9 +43,12 @@ contract MirrorServiceHandlerTest is Test {
     uint256[] private weights;
     uint256[] private privateKeys;
 
-    error MirrorServiceHandlerTest__BlockNumberTooLowForOffset();
-    error MirrorServiceHandlerTest__ArraysLengthMismatch();
-    error MirrorServiceHandlerTest__SignatureRecoveryFailed();
+    /// @notice The error for the block number too low for offset.
+    error MirrorQuorumSyncHandlerTest__BlockNumberTooLowForOffset();
+    /// @notice The error for the arrays length mismatch.
+    error MirrorQuorumSyncHandlerTest__ArraysLengthMismatch();
+    /// @notice The error for the signature recovery failed.
+    error MirrorQuorumSyncHandlerTest__SignatureRecoveryFailed();
 
     /// @notice The setUp function.
     function setUp() public {
@@ -56,8 +60,7 @@ contract MirrorServiceHandlerTest is Test {
         proxyAdmin = UpgradeableProxyLib.deployProxyAdmin();
 
         // Deploy contracts
-        WavsMirrorDeploymentLib.DeploymentData memory deployment =
-            WavsMirrorDeploymentLib.deployContracts(proxyAdmin);
+        deployment = WavsMirrorDeploymentLib.deployContracts(proxyAdmin);
 
         // Create references to deployed contracts
         serviceManager = WavsServiceManager(deployment.wavsServiceManager);
@@ -86,10 +89,10 @@ contract MirrorServiceHandlerTest is Test {
         stakeRegistry.batchSetOperatorDetails(operators, signingKeyAddresses, weights);
         vm.stopPrank();
 
-        // Deploy MirrorServiceHandler
+        // Deploy MirrorQuorumSyncHandler
         vm.startPrank(actualOwner);
         deployment = WavsMirrorDeploymentLib.deployServiceHandlers(deployment);
-        serviceHandler = MirrorServiceHandler(deployment.mirrorServiceHandler);
+        serviceHandler = MirrorQuorumSyncHandler(deployment.quorumSyncHandler);
         vm.stopPrank();
 
         // Roll to block 10 to ensure we have enough blocks for reference blocks
@@ -100,69 +103,24 @@ contract MirrorServiceHandlerTest is Test {
     /// @notice The test_initial_state function.
     function test_initial_state() public view {
         /* solhint-enable func-name-mixedcase */
-        // Verify deployment addresses are set correctly
-        assertNotEq(address(serviceHandler), address(0), "ServiceHandler address cannot be zero");
-
-        // Verify contract references
-        assertEq(
-            address(serviceHandler.getStakeRegistry()),
-            address(stakeRegistry),
-            "ServiceHandler should reference correct StakeRegistry"
-        );
-
+        // Test initial state of the service handler
+        assertEq(serviceHandler.lastTriggerId(), 0, "Initial trigger ID should be 0");
         assertEq(
             address(serviceHandler.getServiceManager()),
             address(serviceManager),
-            "ServiceHandler should reference correct ServiceManager"
+            "Service manager address should be set"
         );
-
-        // Verify initial trigger ID is 0
-        assertEq(serviceHandler.lastTriggerId(), 0, "Initial trigger ID should be 0");
-
-        // Verify that the owner of the stakeRegistry is the serviceHandler
-        assertEq(
-            stakeRegistry.owner(),
-            address(serviceHandler),
-            "ServiceHandler should be the owner of stakeRegistry"
-        );
-    }
-
-    /* solhint-disable func-name-mixedcase */
-    /// @notice The test_invalid_payload function.
-    function test_invalid_payload() public {
-        /* solhint-enable func-name-mixedcase */
-        // Create an envelope with invalid payload
-        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
-            eventId: bytes20(uint160(1)),
-            ordering: bytes12(0),
-            payload: abi.encode("Bad payload")
-        });
-
-        // Create signature data with 4 operators (more than enough to pass quorum)
-        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 4, 5);
-
-        // Call handleSignedEnvelope should fail with invalid payload
-        vm.expectRevert();
-        serviceHandler.handleSignedEnvelope(envelope, signatureData);
+        assertEq(serviceManager.quorumNumerator(), 2, "Initial quorum numerator should be 2");
+        assertEq(serviceManager.quorumDenominator(), 3, "Initial quorum denominator should be 3");
     }
 
     /* solhint-disable func-name-mixedcase */
     /// @notice The test_invalid_trigger_id function.
     function test_invalid_trigger_id() public {
         /* solhint-enable func-name-mixedcase */
-        // Keep the same operators
-        address[] memory newOperators = operators;
-        address[] memory newSigningKeyAddresses = signingKeyAddresses;
-        uint256[] memory newWeights = weights;
-
-        // Update to triggerId 5
-        IMirrorUpdateTypes.UpdateWithId memory updateData = IMirrorUpdateTypes.UpdateWithId({
-            triggerId: 5,
-            thresholdWeight: 5000,
-            operators: newOperators,
-            signingKeyAddresses: newSigningKeyAddresses,
-            weights: newWeights
-        });
+        // update trigger to 5
+        IMirrorQuorumSyncHandler.UpdateWithId memory updateData =
+            IMirrorQuorumSyncHandler.UpdateWithId({triggerId: 5, numerator: 2, denominator: 3});
         // Create envelope with the encoded payload
         IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
             eventId: bytes20(uint160(1)),
@@ -170,37 +128,33 @@ contract MirrorServiceHandlerTest is Test {
             payload: abi.encode(updateData)
         });
 
-        // Create signature data with 4 operators (more than enough to pass quorum)
-        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 4, 5);
-        // Will pass and update to 5
+        // Create signature data with all operators (5/5)
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 5, 0);
+        // Passes first time
         serviceHandler.handleSignedEnvelope(envelope, signatureData);
 
-        // ensure it is updated
-        assertEq(serviceHandler.lastTriggerId(), 5, "Initial trigger ID should be 5");
-
-        // Try again will fail (reply)
-        vm.expectRevert(abi.encodeWithSelector(IMirrorUpdateTypes.InvalidTriggerId.selector, 5));
+        // Replay should fail with InvalidTriggerId
+        vm.expectRevert(
+            abi.encodeWithSelector(IMirrorQuorumSyncHandler.InvalidTriggerId.selector, 5)
+        );
         serviceHandler.handleSignedEnvelope(envelope, signatureData);
 
-        // Previous trigger id will fail
-        updateData = IMirrorUpdateTypes.UpdateWithId({
-            triggerId: 3, // 3 < 5
-            thresholdWeight: 5000,
-            operators: newOperators,
-            signingKeyAddresses: newSigningKeyAddresses,
-            weights: newWeights
-        });
+        // Try lower trigger id (2) to show it fails
+        updateData =
+            IMirrorQuorumSyncHandler.UpdateWithId({triggerId: 2, numerator: 3, denominator: 4});
         // Create envelope with the encoded payload
         envelope = IWavsServiceHandler.Envelope({
             eventId: bytes20(uint160(2)),
             ordering: bytes12(0),
             payload: abi.encode(updateData)
         });
-        // Create signature data with 4 operators (more than enough to pass quorum)
-        signatureData = createSignatureData(envelope, 4, 5);
+        // Create signature data with all operators (5/5)
+        signatureData = createSignatureData(envelope, 5, 0);
 
-        // but fails
-        vm.expectRevert(abi.encodeWithSelector(IMirrorUpdateTypes.InvalidTriggerId.selector, 5));
+        // Previous id should fail with InvalidTriggerId
+        vm.expectRevert(
+            abi.encodeWithSelector(IMirrorQuorumSyncHandler.InvalidTriggerId.selector, 5)
+        );
         serviceHandler.handleSignedEnvelope(envelope, signatureData);
     }
 
@@ -209,22 +163,8 @@ contract MirrorServiceHandlerTest is Test {
     function test_insufficient_quorum() public {
         /* solhint-enable func-name-mixedcase */
         // Create a valid UpdateWithId payload with triggerId = 1
-        address[] memory newOperators = new address[](1);
-        address[] memory newSigningKeyAddresses = new address[](1);
-        uint256[] memory newWeights = new uint256[](1);
-
-        newOperators[0] = address(0x123);
-        newSigningKeyAddresses[0] = address(0x456);
-        newWeights[0] = 10_000;
-
-        // Create the UpdateWithId struct with triggerId = 1
-        IMirrorUpdateTypes.UpdateWithId memory updateData = IMirrorUpdateTypes.UpdateWithId({
-            triggerId: 1,
-            thresholdWeight: 5000,
-            operators: newOperators,
-            signingKeyAddresses: newSigningKeyAddresses,
-            weights: newWeights
-        });
+        IMirrorQuorumSyncHandler.UpdateWithId memory updateData =
+            IMirrorQuorumSyncHandler.UpdateWithId({triggerId: 1, numerator: 2, denominator: 3});
 
         // Create envelope with the encoded payload
         IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
@@ -233,50 +173,52 @@ contract MirrorServiceHandlerTest is Test {
             payload: abi.encode(updateData)
         });
 
-        // Create signature data with only 3 operators (not enough for quorum)
-        // The quorum is 4/5 (80%) in the default setup
-        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 3, 5);
+        // Create signature data with only 2 operators (not enough for quorum)
+        // The quorum is 3/5 (60%) in the default setup
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 2, 0);
 
         // Call handleSignedEnvelope should fail with InsufficientQuorum
-        // Note: The actual error will come from the serviceManager.validate() call inside handleSignedEnvelope
-        // which will revert with InsufficientQuorum error
-        // The actual values are slightly different due to integer division in the contract
         vm.expectRevert(
             abi.encodeWithSignature(
                 "InsufficientQuorum(uint256,uint256,uint256)",
-                30_000, // 3/5 * 10000 = 6000 (but in basis points, so 30000)
-                33_333, // 1/3 in basis points (rounded up from 33333.33...)
-                50_000 // 1/2 in basis points (due to integer math in the contract)
+                20_000, // has
+                33_333, // needs
+                50_000 // max
             )
         );
         serviceHandler.handleSignedEnvelope(envelope, signatureData);
     }
 
-    /* solhint-disable func-name-mixedcase */
-    /// @notice The test_successful_update_weight function.
-    function test_successful_update_weight() public {
-        /* solhint-enable func-name-mixedcase */
-        // let's change the weights and a public key
-        // now op1 and op2 have 2/3 and can pass a future round
-        address[] memory newOperators = new address[](2);
-        address[] memory newSigningKeyAddresses = new address[](2);
-        uint256[] memory newWeights = new uint256[](2);
-
-        // after this, we have 30k, 30k, 10k, 10k, 10k
-        for (uint256 i = 0; i < 2; ++i) {
-            newOperators[i] = operators[i];
-            newSigningKeyAddresses[i] = signingKeyAddresses[i];
-            newWeights[i] = OPERATOR_WEIGHT * 3;
-        }
-
-        // Create the UpdateWithId struct with triggerId = 1
-        IMirrorUpdateTypes.UpdateWithId memory updateData = IMirrorUpdateTypes.UpdateWithId({
-            triggerId: 1,
-            thresholdWeight: 8000,
-            operators: newOperators,
-            signingKeyAddresses: newSigningKeyAddresses,
-            weights: newWeights
+    /*
+    // TODO: no error on parse. how to validate?
+    function test_invalid_payload() public {
+        // Create an invalid payload (not matching UpdateWithId struct)
+        bytes memory invalidPayload = abi.encode("BAD");
+        
+        // Create envelope with the invalid payload
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
+            eventId: bytes20(uint160(1)),
+            ordering: bytes12(0),
+            payload: invalidPayload
         });
+        
+        // Create signature data with all operators (5/5)
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 5, 5);
+        
+        // Call handleSignedEnvelope should fail with abi decode error
+        vm.expectRevert(); // Decoding error
+        serviceHandler.handleSignedEnvelope(envelope, signatureData);
+    }
+    */
+
+    /* solhint-disable func-name-mixedcase */
+    /// @notice The test_successful_update_quorum function.
+    function test_successful_update_quorum() public {
+        /* solhint-enable func-name-mixedcase */
+        // let's change quorum so 2/5 (4/10)can pass, not 2/3
+        // Create the UpdateWithId struct with triggerId = 1
+        IMirrorQuorumSyncHandler.UpdateWithId memory updateData =
+            IMirrorQuorumSyncHandler.UpdateWithId({triggerId: 1, numerator: 4, denominator: 10});
 
         // Create envelope with the encoded payload
         IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
@@ -290,45 +232,12 @@ contract MirrorServiceHandlerTest is Test {
         serviceHandler.handleSignedEnvelope(envelope, signatureData);
 
         // Check that the lastTriggerId was incremented
-        assertEq(
-            stakeRegistry.getLastCheckpointThresholdWeight(), 8000, "stakeThreshold not updated"
-        );
         assertEq(serviceHandler.lastTriggerId(), 1, "lastTriggerId not incremented");
+        assertEq(serviceManager.quorumNumerator(), 4, "Initial quorum numerator should be 4");
+        assertEq(serviceManager.quorumDenominator(), 10, "Initial quorum denominator should be 10");
 
-        // Move forward in blocks to ensure the previous update is finalized
-        uint256 startBlock = vm.getBlockNumber();
-        uint256 stepOne = startBlock + 10;
-        vm.roll(stepOne + 1);
-
-        // Check the weights were updated at the block of the first update
-        for (uint256 i = 0; i < 2; ++i) {
-            uint256 weight =
-                stakeRegistry.getOperatorWeightAtBlock(newOperators[i], uint32(stepOne));
-            assertEq(weight, newWeights[i], "Operator weight not updated");
-        }
-
-        uint256 totalWeight = stakeRegistry.getLastCheckpointTotalWeightAtBlock(uint32(stepOne));
-        assertEq(totalWeight, 90_000, "Total weight not updated");
-
-        newOperators = new address[](3);
-        newSigningKeyAddresses = new address[](3);
-        newWeights = new uint256[](3);
-
-        // Set up the next update - setting weights to 0 for the last 3 operators
-        for (uint256 i = 0; i < 3; ++i) {
-            newOperators[i] = operators[i + 2];
-            newSigningKeyAddresses[i] = signingKeyAddresses[i + 2];
-            newWeights[i] = 0;
-        }
-
-        // Create the UpdateWithId struct with triggerId = 2
-        updateData = IMirrorUpdateTypes.UpdateWithId({
-            triggerId: 2,
-            thresholdWeight: 6500,
-            operators: newOperators,
-            signingKeyAddresses: newSigningKeyAddresses,
-            weights: newWeights
-        });
+        updateData =
+            IMirrorQuorumSyncHandler.UpdateWithId({triggerId: 2, numerator: 1, denominator: 6});
 
         // Create envelope with the encoded payload
         envelope = IWavsServiceHandler.Envelope({
@@ -337,31 +246,14 @@ contract MirrorServiceHandlerTest is Test {
             payload: abi.encode(updateData)
         });
 
-        // First 2 operators now have 2/3 and can pass
+        // 2/5 is now enough to pass
         signatureData = createSignatureData(envelope, 2, 0);
-
-        // Call handleSignedEnvelope
         serviceHandler.handleSignedEnvelope(envelope, signatureData);
 
-        // Move forward in blocks to ensure the previous update is finalized
-        uint256 stepTwo = startBlock + 20;
-        vm.roll(stepTwo + 1);
-
         // Check that the lastTriggerId was incremented
-        assertEq(
-            stakeRegistry.getLastCheckpointThresholdWeight(), 6500, "stakeThreshold not updated"
-        );
         assertEq(serviceHandler.lastTriggerId(), 2, "lastTriggerId not incremented to 2");
-
-        uint256 newTotalWeight = stakeRegistry.getLastCheckpointTotalWeightAtBlock(uint32(stepTwo));
-        assertEq(newTotalWeight, 60_000, "Total weight not updated");
-
-        // Check that the operator weights were properly updated (0s for the other operators)
-        for (uint256 i = 0; i < 3; ++i) {
-            uint256 weight =
-                stakeRegistry.getOperatorWeightAtBlock(newOperators[i], uint32(stepTwo));
-            assertEq(weight, 0, "Operator weight not set to 0");
-        }
+        assertEq(serviceManager.quorumNumerator(), 1, "Initial quorum numerator should be 1");
+        assertEq(serviceManager.quorumDenominator(), 6, "Initial quorum denominator should be 6");
     }
 
     /**
@@ -392,7 +284,7 @@ contract MirrorServiceHandlerTest is Test {
             signatures[i] = generateSignature(privateKeys[i], digest);
         }
 
-        // Sort signers and signatures by signer address11
+        // Sort signers and signatures by signer address
         sortSignersAndSignatures(signers, signatures);
 
         // Verify signatures
@@ -403,7 +295,7 @@ contract MirrorServiceHandlerTest is Test {
         // Make sure we're at least at block 1 before subtracting offset
         uint32 currentBlock = uint32(block.number);
         if (!(currentBlock > referenceBlockOffset)) {
-            revert MirrorServiceHandlerTest__BlockNumberTooLowForOffset();
+            revert MirrorQuorumSyncHandlerTest__BlockNumberTooLowForOffset();
         }
 
         return IWavsServiceHandler.SignatureData({
@@ -468,13 +360,13 @@ contract MirrorServiceHandlerTest is Test {
         bytes[] memory signatures
     ) internal pure {
         if (signers.length != signatures.length) {
-            revert MirrorServiceHandlerTest__ArraysLengthMismatch();
+            revert MirrorQuorumSyncHandlerTest__ArraysLengthMismatch();
         }
 
         for (uint256 i = 0; i < signers.length; ++i) {
             address recovered = ECDSA.recover(digest, signatures[i]);
             if (recovered != signers[i]) {
-                revert MirrorServiceHandlerTest__SignatureRecoveryFailed();
+                revert MirrorQuorumSyncHandlerTest__SignatureRecoveryFailed();
             }
         }
     }

--- a/contracts/test/eigenlayer/ecdsa/WavsOperatorUpdateHandler.t.sol
+++ b/contracts/test/eigenlayer/ecdsa/WavsOperatorUpdateHandler.t.sol
@@ -6,93 +6,111 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {ECDSAUpgradeable} from
     "@openzeppelin-upgrades/contracts/utils/cryptography/ECDSAUpgradeable.sol";
 
-import {WavsMirrorDeploymentLib} from "script/eigenlayer/ecdsa/utils/WavsMirrorDeploymentLib.sol";
-import {UpgradeableProxyLib} from "script/eigenlayer/ecdsa/utils/UpgradeableProxyLib.sol";
-import {MirrorStakeRegistry} from "src/eigenlayer/ecdsa/MirrorStakeRegistry.sol";
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ECDSAStakeRegistry} from "@eigenlayer-middleware/src/unaudited/ECDSAStakeRegistry.sol";
 import {WavsServiceManager} from "src/eigenlayer/ecdsa/WavsServiceManager.sol";
 import {
-    MirrorServiceManagerHandler,
-    IManagerUpdateTypes
-} from "src/eigenlayer/ecdsa/handlers/MirrorServiceManagerHandler.sol";
+    WavsOperatorUpdateHandler,
+    IWavsOperatorUpdateHandler
+} from "src/eigenlayer/ecdsa/handlers/WavsOperatorUpdateHandler.sol";
 import {IWavsServiceHandler} from "src/eigenlayer/ecdsa/interfaces/IWavsServiceHandler.sol";
+import {MockStakeRegistry} from "test/eigenlayer/ecdsa/mocks/MockStakeRegistry.sol";
 
 /**
- * @title MirrorServiceManagerHandlerTest
+ * @title WavsOperatorUpdateHandlerTest
  * @author Lay3rLabs
- * @notice This contract contains tests for the MirrorServiceManagerHandler contract.
- * @dev This contract is used to test the MirrorServiceManagerHandler contract.
+ * @notice This contract contains tests for the WavsOperatorUpdateHandler contract.
+ * @dev This contract is used to test the WavsOperatorUpdateHandler contract.
  */
-contract MirrorServiceManagerHandlerTest is Test {
-    using UpgradeableProxyLib for address;
-
+contract WavsOperatorUpdateHandlerTest is Test {
     // Constants
     uint256 private constant OPERATOR_WEIGHT = 10_000;
 
     address private deployer;
-    address private proxyAdmin;
-    WavsMirrorDeploymentLib.DeploymentData private deployment;
+    address private proxyOwner;
 
     // Contract references
-    MirrorStakeRegistry private stakeRegistry;
+    MockStakeRegistry private stakeRegistry;
     WavsServiceManager private serviceManager;
-    MirrorServiceManagerHandler private serviceHandler;
+    WavsOperatorUpdateHandler private serviceHandler;
 
     // Basic operator data
     address[] private operators;
-    address[] private signingKeyAddresses;
     uint256[] private weights;
     uint256[] private privateKeys;
 
     /// @notice The error for the block number too low for offset.
-    error MirrorServiceManagerHandlerTest__BlockNumberTooLowForOffset();
+    error WavsOperatorUpdateHandlerTest__BlockNumberTooLowForOffset();
     /// @notice The error for the arrays length mismatch.
-    error MirrorServiceManagerHandlerTest__ArraysLengthMismatch();
+    error WavsOperatorUpdateHandlerTest__ArraysLengthMismatch();
     /// @notice The error for the signature recovery failed.
-    error MirrorServiceManagerHandlerTest__SignatureRecoveryFailed();
+    error WavsOperatorUpdateHandlerTest__SignatureRecoveryFailed();
 
     /// @notice The setUp function.
     function setUp() public {
-        // Set up deployer address
+        // Set up deployer addresses
         deployer = address(0x123);
+        proxyOwner = address(0x456);
+
         vm.startPrank(deployer);
+        stakeRegistry = new MockStakeRegistry();
 
-        // Deploy proxy admin
-        proxyAdmin = UpgradeableProxyLib.deployProxyAdmin();
+        // Deploy the implementation contract
+        WavsServiceManager implementation = new WavsServiceManager(
+            address(this), // avsDirectory
+            address(stakeRegistry),
+            address(0x101),
+            address(0x102),
+            address(0x103)
+        );
+        vm.stopPrank();
 
-        // Deploy contracts
-        deployment = WavsMirrorDeploymentLib.deployContracts(proxyAdmin);
+        vm.startPrank(proxyOwner);
 
-        // Create references to deployed contracts
-        serviceManager = WavsServiceManager(deployment.wavsServiceManager);
-        stakeRegistry = MirrorStakeRegistry(deployment.stakeRegistry);
+        // Encode the initialize function call
+        bytes memory data = abi.encodeWithSelector(
+            WavsServiceManager.initialize.selector,
+            deployer, // initialOwner
+            deployer // rewardsInitiator
+        );
+        // Deploy the proxy and initialize it
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(implementation),
+            proxyOwner, // admin
+            data // initializer data
+        );
+        // Cast the proxy to the service manager interface
+        serviceManager = WavsServiceManager(address(proxy));
 
         vm.stopPrank();
+
+        vm.startPrank(deployer);
+
+        serviceHandler = new WavsOperatorUpdateHandler(
+            serviceManager, ECDSAStakeRegistry(address(stakeRegistry))
+        );
 
         // Create test info for 5 operators
         privateKeys = new uint256[](5);
         operators = new address[](5);
-        signingKeyAddresses = new address[](5);
         weights = new uint256[](5);
 
         for (uint256 i = 0; i < 5; ++i) {
             privateKeys[i] = i + 1;
             operators[i] = vm.addr(privateKeys[i]);
-            signingKeyAddresses[i] = vm.addr(privateKeys[i]);
             weights[i] = OPERATOR_WEIGHT;
         }
 
-        // Find out the actual owner of the contracts
-        address actualOwner = serviceManager.owner();
+        // Set up test operator weights
+        stakeRegistry.setOperatorWeight(operators[0], weights[0]);
+        stakeRegistry.setOperatorWeight(operators[1], weights[1]);
+        stakeRegistry.setOperatorWeight(operators[2], weights[2]);
+        stakeRegistry.setOperatorWeight(operators[3], weights[3]);
+        stakeRegistry.setOperatorWeight(operators[4], weights[4]);
+        stakeRegistry.setTotalWeight(weights[0] + weights[1] + weights[2] + weights[3] + weights[4]);
+        stakeRegistry.setTotalOperators(5);
 
-        // Set up test operator weights as the actual owner
-        vm.startPrank(actualOwner);
-        stakeRegistry.batchSetOperatorDetails(operators, signingKeyAddresses, weights);
-        vm.stopPrank();
-
-        // Deploy MirrorServiceManagerHandler
-        vm.startPrank(actualOwner);
-        deployment = WavsMirrorDeploymentLib.deployServiceHandlers(deployment);
-        serviceHandler = MirrorServiceManagerHandler(deployment.mirrorServiceManagerHandler);
         vm.stopPrank();
 
         // Roll to block 10 to ensure we have enough blocks for reference blocks
@@ -104,52 +122,34 @@ contract MirrorServiceManagerHandlerTest is Test {
     function test_initial_state() public view {
         /* solhint-enable func-name-mixedcase */
         // Test initial state of the service handler
-        assertEq(serviceHandler.lastTriggerId(), 0, "Initial trigger ID should be 0");
         assertEq(
             address(serviceHandler.getServiceManager()),
             address(serviceManager),
             "Service manager address should be set"
         );
-        assertEq(serviceManager.quorumNumerator(), 2, "Initial quorum numerator should be 2");
-        assertEq(serviceManager.quorumDenominator(), 3, "Initial quorum denominator should be 3");
+        assertEq(
+            address(serviceHandler.getStakeRegistry()),
+            address(stakeRegistry),
+            "Stake registry address should be set"
+        );
     }
 
     /* solhint-disable func-name-mixedcase */
-    /// @notice The test_invalid_trigger_id function.
-    function test_invalid_trigger_id() public {
+    /// @notice The test_invalid_payload function.
+    function test_invalid_payload() public {
         /* solhint-enable func-name-mixedcase */
-        // update trigger to 5
-        IManagerUpdateTypes.UpdateWithId memory updateData =
-            IManagerUpdateTypes.UpdateWithId({triggerId: 5, numerator: 2, denominator: 3});
-        // Create envelope with the encoded payload
+        // Create an envelope with invalid payload
         IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
             eventId: bytes20(uint160(1)),
             ordering: bytes12(0),
-            payload: abi.encode(updateData)
+            payload: abi.encode("Bad payload")
         });
 
-        // Create signature data with all operators (5/5)
-        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 5, 0);
-        // Passes first time
-        serviceHandler.handleSignedEnvelope(envelope, signatureData);
+        // Create signature data with 4 operators (more than enough to pass quorum)
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 4, 5);
 
-        // Replay should fail with InvalidTriggerId
-        vm.expectRevert(abi.encodeWithSelector(IManagerUpdateTypes.InvalidTriggerId.selector, 5));
-        serviceHandler.handleSignedEnvelope(envelope, signatureData);
-
-        // Try lower trigger id (2) to show it fails
-        updateData = IManagerUpdateTypes.UpdateWithId({triggerId: 2, numerator: 3, denominator: 4});
-        // Create envelope with the encoded payload
-        envelope = IWavsServiceHandler.Envelope({
-            eventId: bytes20(uint160(2)),
-            ordering: bytes12(0),
-            payload: abi.encode(updateData)
-        });
-        // Create signature data with all operators (5/5)
-        signatureData = createSignatureData(envelope, 5, 0);
-
-        // Previous id should fail with InvalidTriggerId
-        vm.expectRevert(abi.encodeWithSelector(IManagerUpdateTypes.InvalidTriggerId.selector, 5));
+        // Call handleSignedEnvelope should fail with invalid payload
+        vm.expectRevert();
         serviceHandler.handleSignedEnvelope(envelope, signatureData);
     }
 
@@ -158,8 +158,11 @@ contract MirrorServiceManagerHandlerTest is Test {
     function test_insufficient_quorum() public {
         /* solhint-enable func-name-mixedcase */
         // Create a valid UpdateWithId payload with triggerId = 1
-        IManagerUpdateTypes.UpdateWithId memory updateData =
-            IManagerUpdateTypes.UpdateWithId({triggerId: 1, numerator: 2, denominator: 3});
+        IWavsOperatorUpdateHandler.OperatorUpdatePayload memory updateData =
+        IWavsOperatorUpdateHandler.OperatorUpdatePayload({
+            operatorsPerQuorum: new address[][](0),
+            quorumNumbers: new bytes(0)
+        });
 
         // Create envelope with the encoded payload
         IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
@@ -184,36 +187,16 @@ contract MirrorServiceManagerHandlerTest is Test {
         serviceHandler.handleSignedEnvelope(envelope, signatureData);
     }
 
-    /*
-    // TODO: no error on parse. how to validate?
-    function test_invalid_payload() public {
-        // Create an invalid payload (not matching UpdateWithId struct)
-        bytes memory invalidPayload = abi.encode("BAD");
-        
-        // Create envelope with the invalid payload
-        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
-            eventId: bytes20(uint160(1)),
-            ordering: bytes12(0),
-            payload: invalidPayload
-        });
-        
-        // Create signature data with all operators (5/5)
-        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 5, 5);
-        
-        // Call handleSignedEnvelope should fail with abi decode error
-        vm.expectRevert(); // Decoding error
-        serviceHandler.handleSignedEnvelope(envelope, signatureData);
-    }
-    */
-
     /* solhint-disable func-name-mixedcase */
-    /// @notice The test_successful_update_quorum function.
-    function test_successful_update_quorum() public {
+    /// @notice The test_failed_update_operators function.
+    function test_failed_update_operators() public {
         /* solhint-enable func-name-mixedcase */
-        // let's change quorum so 2/5 (4/10)can pass, not 2/3
-        // Create the UpdateWithId struct with triggerId = 1
-        IManagerUpdateTypes.UpdateWithId memory updateData =
-            IManagerUpdateTypes.UpdateWithId({triggerId: 1, numerator: 4, denominator: 10});
+        // Create the update data with some operators
+        IWavsOperatorUpdateHandler.OperatorUpdatePayload memory updateData =
+        IWavsOperatorUpdateHandler.OperatorUpdatePayload({
+            operatorsPerQuorum: new address[][](1),
+            quorumNumbers: new bytes(0)
+        });
 
         // Create envelope with the encoded payload
         IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
@@ -224,30 +207,50 @@ contract MirrorServiceManagerHandlerTest is Test {
 
         // 4/5 can pass this with > 2/3
         IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 4, 0);
+
+        // Call handleSignedEnvelope should fail with MustUpdateAllOperators
+        vm.expectRevert(abi.encodeWithSignature("MustUpdateAllOperators()"));
         serviceHandler.handleSignedEnvelope(envelope, signatureData);
+    }
 
-        // Check that the lastTriggerId was incremented
-        assertEq(serviceHandler.lastTriggerId(), 1, "lastTriggerId not incremented");
-        assertEq(serviceManager.quorumNumerator(), 4, "Initial quorum numerator should be 4");
-        assertEq(serviceManager.quorumDenominator(), 10, "Initial quorum denominator should be 10");
-
-        updateData = IManagerUpdateTypes.UpdateWithId({triggerId: 2, numerator: 1, denominator: 6});
+    /* solhint-disable func-name-mixedcase */
+    /// @notice The test_successful_update_operators function.
+    function test_successful_update_operators() public {
+        /* solhint-enable func-name-mixedcase */
+        // Create the update data
+        address[][] memory operatorsPerQuorum = new address[][](1);
+        operatorsPerQuorum[0] = operators;
+        IWavsOperatorUpdateHandler.OperatorUpdatePayload memory updateData =
+        IWavsOperatorUpdateHandler.OperatorUpdatePayload({
+            operatorsPerQuorum: operatorsPerQuorum,
+            quorumNumbers: new bytes(0)
+        });
 
         // Create envelope with the encoded payload
-        envelope = IWavsServiceHandler.Envelope({
+        IWavsServiceHandler.Envelope memory envelope = IWavsServiceHandler.Envelope({
             eventId: bytes20(uint160(1)),
             ordering: bytes12(0),
             payload: abi.encode(updateData)
         });
 
-        // 2/5 is now enough to pass
-        signatureData = createSignatureData(envelope, 2, 0);
+        // 4/5 can pass this with > 2/3
+        IWavsServiceHandler.SignatureData memory signatureData = createSignatureData(envelope, 4, 0);
+
+        // total weight starts at all the weights
+        uint256 initialTotalWeight = weights[0] + weights[1] + weights[2] + weights[3] + weights[4];
+        assertEq(
+            stakeRegistry.totalWeight(),
+            initialTotalWeight,
+            "Total weight should initialize to the sum of the initial weights"
+        );
+
+        // update the operators
         serviceHandler.handleSignedEnvelope(envelope, signatureData);
 
-        // Check that the lastTriggerId was incremented
-        assertEq(serviceHandler.lastTriggerId(), 2, "lastTriggerId not incremented to 2");
-        assertEq(serviceManager.quorumNumerator(), 1, "Initial quorum numerator should be 1");
-        assertEq(serviceManager.quorumDenominator(), 6, "Initial quorum denominator should be 6");
+        // mock stake registry doubles even weights and halves odd weights
+        uint256 newTotalWeight =
+            weights[0] * 2 + weights[1] / 2 + weights[2] * 2 + weights[3] / 2 + weights[4] * 2;
+        assertEq(stakeRegistry.totalWeight(), newTotalWeight, "Total weight should be updated");
     }
 
     /**
@@ -289,7 +292,7 @@ contract MirrorServiceManagerHandlerTest is Test {
         // Make sure we're at least at block 1 before subtracting offset
         uint32 currentBlock = uint32(block.number);
         if (!(currentBlock > referenceBlockOffset)) {
-            revert MirrorServiceManagerHandlerTest__BlockNumberTooLowForOffset();
+            revert WavsOperatorUpdateHandlerTest__BlockNumberTooLowForOffset();
         }
 
         return IWavsServiceHandler.SignatureData({
@@ -354,13 +357,13 @@ contract MirrorServiceManagerHandlerTest is Test {
         bytes[] memory signatures
     ) internal pure {
         if (signers.length != signatures.length) {
-            revert MirrorServiceManagerHandlerTest__ArraysLengthMismatch();
+            revert WavsOperatorUpdateHandlerTest__ArraysLengthMismatch();
         }
 
         for (uint256 i = 0; i < signers.length; ++i) {
             address recovered = ECDSA.recover(digest, signatures[i]);
             if (recovered != signers[i]) {
-                revert MirrorServiceManagerHandlerTest__SignatureRecoveryFailed();
+                revert WavsOperatorUpdateHandlerTest__SignatureRecoveryFailed();
             }
         }
     }

--- a/contracts/test/eigenlayer/ecdsa/mocks/MockStakeRegistry.sol
+++ b/contracts/test/eigenlayer/ecdsa/mocks/MockStakeRegistry.sol
@@ -71,18 +71,19 @@ contract MockStakeRegistry is IECDSAStakeRegistryErrors {
     /**
      * @notice The updateOperatorsForQuorum function.
      * @param operatorsPerQuorum The operators per quorum.
+     * @param {_signature} The signature.
      * @dev This function doubles the weights of even operators and halves the weights of odd operators, for testing.
      */
-    function updateOperatorsForQuorum(
-        address[][] memory operatorsPerQuorum,
-        bytes memory
+    function updateOperatorsForQuorum( // solhint-disable-line use-natspec
+        address[][] calldata operatorsPerQuorum,
+        bytes calldata /* _signature */
     ) external virtual {
         address[] memory operators = operatorsPerQuorum[0];
         if (operators.length != totalOperators) {
             revert MustUpdateAllOperators();
         }
         int256 delta;
-        for (uint256 i; i < operators.length; i++) {
+        for (uint256 i; i < operators.length; ++i) {
             uint256 oldWeight = operatorWeights[operators[i]];
             uint256 newWeight;
             if (i % 2 == 0) {

--- a/contracts/test/eigenlayer/ecdsa/mocks/MockStakeRegistry.sol
+++ b/contracts/test/eigenlayer/ecdsa/mocks/MockStakeRegistry.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.27;
 
 import {IERC1271Upgradeable} from
     "@openzeppelin-upgrades/contracts/interfaces/IERC1271Upgradeable.sol";
+import {IECDSAStakeRegistryErrors} from
+    "@eigenlayer-middleware/src/interfaces/IECDSAStakeRegistry.sol";
 
 /**
  * @title MockStakeRegistry
@@ -10,7 +12,7 @@ import {IERC1271Upgradeable} from
  * @notice This contract is a mock stake registry for testing the WavsServiceManager contract.
  * @dev This contract is used to test the WavsServiceManager contract.
  */
-contract MockStakeRegistry {
+contract MockStakeRegistry is IECDSAStakeRegistryErrors {
     /// @notice The operator to signing key mapping.
     mapping(address => address) public operatorToSigning;
     /// @notice The signing key to operator mapping.
@@ -19,6 +21,8 @@ contract MockStakeRegistry {
     mapping(address => uint256) public operatorWeights;
     /// @notice The total weight.
     uint256 public totalWeight;
+    /// @notice The total operators.
+    uint256 public totalOperators;
 
     /**
      * @notice The setOperatorWeight function.
@@ -52,6 +56,44 @@ contract MockStakeRegistry {
         uint256 _totalWeight
     ) external {
         totalWeight = _totalWeight;
+    }
+
+    /**
+     * @notice The setTotalOperators function.
+     * @param _totalOperators The total operators.
+     */
+    function setTotalOperators(
+        uint256 _totalOperators
+    ) external {
+        totalOperators = _totalOperators;
+    }
+
+    /**
+     * @notice The updateOperatorsForQuorum function.
+     * @param operatorsPerQuorum The operators per quorum.
+     * @dev This function doubles the weights of even operators and halves the weights of odd operators, for testing.
+     */
+    function updateOperatorsForQuorum(
+        address[][] memory operatorsPerQuorum,
+        bytes memory
+    ) external virtual {
+        address[] memory operators = operatorsPerQuorum[0];
+        if (operators.length != totalOperators) {
+            revert MustUpdateAllOperators();
+        }
+        int256 delta;
+        for (uint256 i; i < operators.length; i++) {
+            uint256 oldWeight = operatorWeights[operators[i]];
+            uint256 newWeight;
+            if (i % 2 == 0) {
+                newWeight = oldWeight * 2;
+            } else {
+                newWeight = oldWeight / 2;
+            }
+            delta += int256(newWeight) - int256(oldWeight);
+            operatorWeights[operators[i]] = newWeight;
+        }
+        totalWeight = uint256(int256(totalWeight) + delta);
     }
 
     /**


### PR DESCRIPTION
As @Reecepbcups, @ismellike, @Supeeerpower, and I discussed last week, there is confusion about where certain code and workflows belong. Our conclusion was:

- the sync services (`avs-sync`, `multi-chain-operator-sync`, `multi-chain-service-manager-sync`) should probably exist separate from `wavs-middleware`, which they do right now in `wavs-tools`, since they are not specific to the chain/VM being submitted to. `wavs-tools` may or may not be the right place for them, but it's fine for now.
- service handler contracts for the sync services *should* exist with the middleware, since they always have to be deployed for each service, and will vary based on the chain/VM (e.g. there will be different avs-sync contract handlers for EVM and CosmWasm, so the handlers should live with the middleware for the respective chain)
- the names need to be more descriptive

The main inconsistency was that `avs-sync`'s `AvsWriter.sol` service handler existed in `wavs-tools`, while `multi-chain-operator-sync` and `multi-chain-service-manager-sync`'s service handlers are in `wavs-middleware` and are automatically deployed with the middleware. To reconcile this, this PR moves `AvsWriter.sol` to this repo, and includes it in the middleware deploy automatically just like the rest of the sync service handlers.

The service handlers were also named confusingly, with `multi-chain-operator-sync`'s service handler called `MirrorServiceHandler.sol`, and `multi-chain-service-manager-sync`'s called `MirrorServiceManagerHandler.sol`. To reconcile this, this PR renames them to `MirrorOperatorSyncHandler.sol` and `MirrorQuorumSyncHandler.sol`, respectively. `avs-sync`'s `AvsWriter.sol` was moved to this repo and renamed to `WavsOperatorUpdateHandler.sol`.

The PR in `wavs-tools` (https://github.com/Lay3rLabs/wavs-tools/pull/96) renames `avs-sync` to `operator-updater` as well as `multi-chain-service-manager-sync` to `multi-chain-quorum-sync` to be more descriptive, which both reflect exactly what they do.